### PR TITLE
feat: Add init command with multi-language support (i18n)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # env file
 .env
+
+# Built binary
+toske

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ja: getDefaultConfigPath はデフォルトの設定ファイルパスを返します
+// ja: 優先順位: TOSKE_CONFIG 環境変数 > ~/.config/toske/config.yml > ./toske-config.yml (フォールバック)
+// en: getDefaultConfigPath returns the default configuration file path
+// en: Priority: TOSKE_CONFIG env var > ~/.config/toske/config.yml > ./toske-config.yml (fallback)
+func getDefaultConfigPath() string {
+	// ja: 最初に環境変数をチェック
+	// en: Check environment variable first
+	if configPath := os.Getenv("TOSKE_CONFIG"); configPath != "" {
+		return configPath
+	}
+
+	// ja: ホームディレクトリ内の XDG 準拠パスを使用
+	// en: Try to use XDG-compliant path in home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		// ja: ホームディレクトリが取得できない場合はカレントディレクトリにフォールバック
+		// en: Fallback to current directory if home dir cannot be determined
+		return "./toske-config.yml"
+	}
+
+	return filepath.Join(homeDir, ".config", "toske", "config.yml")
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,9 +6,9 @@ import (
 )
 
 // ja: getDefaultConfigPath はデフォルトの設定ファイルパスを返します
-// ja: 優先順位: TOSKE_CONFIG 環境変数 > ~/.config/toske/config.yml > ./toske-config.yml (フォールバック)
+// ja: 優先順位: TOSKE_CONFIG 環境変数 > 新パス（存在時） > レガシーパス（存在時） > 新パス（デフォルト）
 // en: getDefaultConfigPath returns the default configuration file path
-// en: Priority: TOSKE_CONFIG env var > ~/.config/toske/config.yml > ./toske-config.yml (fallback)
+// en: Priority: TOSKE_CONFIG env var > new path (if exists) > legacy path (if exists) > new path (default)
 func getDefaultConfigPath() string {
 	// ja: 最初に環境変数をチェック
 	// en: Check environment variable first
@@ -16,8 +16,8 @@ func getDefaultConfigPath() string {
 		return configPath
 	}
 
-	// ja: ホームディレクトリ内の XDG 準拠パスを使用
-	// en: Try to use XDG-compliant path in home directory
+	// ja: ホームディレクトリを取得
+	// en: Get home directory
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		// ja: ホームディレクトリが取得できない場合はカレントディレクトリにフォールバック
@@ -25,5 +25,39 @@ func getDefaultConfigPath() string {
 		return "./toske-config.yml"
 	}
 
-	return filepath.Join(homeDir, ".config", "toske", "config.yml")
+	// ja: 新しい XDG 準拠パス
+	// en: New XDG-compliant path
+	newPath := filepath.Join(homeDir, ".config", "toske", "config.yml")
+
+	// ja: レガシーパス（後方互換性のため）
+	// en: Legacy path (for backward compatibility)
+	legacyPath := filepath.Join(homeDir, ".toske.yaml")
+
+	// ja: 新しいパスが存在する場合はそれを使用
+	// en: Use new path if it exists
+	if _, err := os.Stat(newPath); err == nil {
+		return newPath
+	}
+
+	// ja: レガシーパスが存在する場合はそれを使用（既存ユーザーのため）
+	// en: Use legacy path if it exists (for existing users)
+	if _, err := os.Stat(legacyPath); err == nil {
+		return legacyPath
+	}
+
+	// ja: どちらも存在しない場合は新しいパスをデフォルトとして返す
+	// en: Return new path as default if neither exists
+	return newPath
+}
+
+// ja: isLegacyConfigPath は指定されたパスがレガシーパスかどうかを判定します
+// en: isLegacyConfigPath checks if the given path is a legacy config path
+func isLegacyConfigPath(configPath string) bool {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	legacyPath := filepath.Join(homeDir, ".toske.yaml")
+	return configPath == legacyPath
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -30,7 +30,12 @@ func init() {
 }
 
 func runInit() error {
-	configPath := getDefaultConfigPath()
+	// ja: 設定ファイルパスを決定（優先順位: --config フラグ > TOSKE_CONFIG 環境変数 > デフォルトパス）
+	// en: Determine config file path (priority: --config flag > TOSKE_CONFIG env var > default path)
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = getDefaultConfigPath()
+	}
 
 	// ja: 設定ファイルが既に存在するかチェック
 	// en: Check if config file already exists

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,7 +11,8 @@ import (
 	"github.com/yk-lab/toske/i18n"
 )
 
-// initCmd represents the init command
+// ja: initCmd は init コマンドを表します
+// en: initCmd represents the init command
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: i18n.T("init.short"),
@@ -29,11 +30,13 @@ func init() {
 }
 
 func runInit() error {
-	configPath := getConfigPath()
+	configPath := getDefaultConfigPath()
 
-	// Check if config file already exists
+	// ja: 設定ファイルが既に存在するかチェック
+	// en: Check if config file already exists
 	if _, err := os.Stat(configPath); err == nil {
-		// File exists, ask for confirmation
+		// ja: ファイルが存在する場合、確認を求める
+		// en: File exists, ask for confirmation
 		fmt.Printf(i18n.T("init.fileExists")+"\n", configPath)
 		fmt.Print(i18n.T("init.overwritePrompt"))
 
@@ -50,13 +53,15 @@ func runInit() error {
 		}
 	}
 
-	// Create directory if it doesn't exist
+	// ja: ディレクトリが存在しない場合は作成
+	// en: Create directory if it doesn't exist
 	configDir := filepath.Dir(configPath)
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		return fmt.Errorf(i18n.T("init.createDirError"), err)
 	}
 
-	// Create config file with template
+	// ja: テンプレートを使用して設定ファイルを作成
+	// en: Create config file with template
 	content := getConfigTemplate()
 	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
 		return fmt.Errorf(i18n.T("init.writeFileError"), err)
@@ -74,23 +79,8 @@ func runInit() error {
 	return nil
 }
 
-// getConfigPath returns the configuration file path
-// Priority: TOSKE_CONFIG env var > default path
-func getConfigPath() string {
-	if configPath := os.Getenv("TOSKE_CONFIG"); configPath != "" {
-		return configPath
-	}
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		// Fallback to current directory if home dir cannot be determined
-		return "./toske-config.yml"
-	}
-
-	return filepath.Join(homeDir, ".config", "toske", "config.yml")
-}
-
-// getConfigTemplate returns the default configuration template
+// ja: getConfigTemplate はデフォルトの設定テンプレートを返します
+// en: getConfigTemplate returns the default configuration template
 func getConfigTemplate() string {
 	return `version: 1.0.0
 projects:
@@ -103,7 +93,8 @@ projects:
       - config/
     backup_retention: 3
 
-# Add more projects as needed:
+# ja: 必要に応じてプロジェクトを追加してください:
+# en: Add more projects as needed:
 #  - name: another-project
 #    repo: https://github.com/user/another-project.git
 #    branch: develop

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// initCmd represents the init command
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize configuration file",
+	Long: `Initialize creates a new configuration file at the default location.
+The default path is ~/.config/toske/config.yml
+
+You can override the default path by setting the TOSKE_CONFIG environment variable.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runInit(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}
+
+func runInit() error {
+	configPath := getConfigPath()
+
+	// Check if config file already exists
+	if _, err := os.Stat(configPath); err == nil {
+		// File exists, ask for confirmation
+		fmt.Printf("Configuration file already exists at: %s\n", configPath)
+		fmt.Print("Do you want to overwrite it? [y/N]: ")
+
+		reader := bufio.NewReader(os.Stdin)
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("failed to read input: %w", err)
+		}
+
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response != "y" && response != "yes" {
+			fmt.Println("Initialization cancelled.")
+			return nil
+		}
+	}
+
+	// Create directory if it doesn't exist
+	configDir := filepath.Dir(configPath)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	// Create config file with template
+	content := getConfigTemplate()
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	fmt.Printf("✓ Configuration file created successfully at: %s\n", configPath)
+	fmt.Println("\nNext steps:")
+	fmt.Println("  1. Edit the configuration file to add your projects")
+	fmt.Printf("     toske edit\n")
+	fmt.Println("  2. Validate your configuration")
+	fmt.Printf("     toske validate\n")
+	fmt.Println("  3. Backup your project files")
+	fmt.Printf("     toske backup --project <project-name>\n")
+
+	return nil
+}
+
+// getConfigPath returns the configuration file path
+// Priority: TOSKE_CONFIG env var > default path
+func getConfigPath() string {
+	if configPath := os.Getenv("TOSKE_CONFIG"); configPath != "" {
+		return configPath
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		// Fallback to current directory if home dir cannot be determined
+		return "./toske-config.yml"
+	}
+
+	return filepath.Join(homeDir, ".config", "toske", "config.yml")
+}
+
+// getConfigTemplate returns the default configuration template
+func getConfigTemplate() string {
+	return `version: 1.0.0
+projects:
+  - name: sample-project
+    repo: git@github.com:user/sample-project.git
+    branch: main
+    backup_paths:
+      - .env
+      - db.sqlite3
+      - config/
+    backup_retention: 3
+
+# Add more projects as needed:
+#  - name: another-project
+#    repo: https://github.com/user/another-project.git
+#    branch: develop
+#    backup_paths:
+#      - .env.local
+#      - data/
+#    backup_retention: 5
+`
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,19 +8,17 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/yk-lab/toske/i18n"
 )
 
 // initCmd represents the init command
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize configuration file",
-	Long: `Initialize creates a new configuration file at the default location.
-The default path is ~/.config/toske/config.yml
-
-You can override the default path by setting the TOSKE_CONFIG environment variable.`,
+	Short: i18n.T("init.short"),
+	Long:  i18n.T("init.long"),
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := runInit(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			fmt.Fprintf(os.Stderr, i18n.T("common.error")+"\n", err)
 			os.Exit(1)
 		}
 	},
@@ -36,18 +34,18 @@ func runInit() error {
 	// Check if config file already exists
 	if _, err := os.Stat(configPath); err == nil {
 		// File exists, ask for confirmation
-		fmt.Printf("Configuration file already exists at: %s\n", configPath)
-		fmt.Print("Do you want to overwrite it? [y/N]: ")
+		fmt.Printf(i18n.T("init.fileExists")+"\n", configPath)
+		fmt.Print(i18n.T("init.overwritePrompt"))
 
 		reader := bufio.NewReader(os.Stdin)
 		response, err := reader.ReadString('\n')
 		if err != nil {
-			return fmt.Errorf("failed to read input: %w", err)
+			return fmt.Errorf(i18n.T("init.readInputError"), err)
 		}
 
 		response = strings.TrimSpace(strings.ToLower(response))
 		if response != "y" && response != "yes" {
-			fmt.Println("Initialization cancelled.")
+			fmt.Println(i18n.T("init.cancelled"))
 			return nil
 		}
 	}
@@ -55,23 +53,23 @@ func runInit() error {
 	// Create directory if it doesn't exist
 	configDir := filepath.Dir(configPath)
 	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
+		return fmt.Errorf(i18n.T("init.createDirError"), err)
 	}
 
 	// Create config file with template
 	content := getConfigTemplate()
 	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
-		return fmt.Errorf("failed to write config file: %w", err)
+		return fmt.Errorf(i18n.T("init.writeFileError"), err)
 	}
 
-	fmt.Printf("✓ Configuration file created successfully at: %s\n", configPath)
-	fmt.Println("\nNext steps:")
-	fmt.Println("  1. Edit the configuration file to add your projects")
-	fmt.Printf("     toske edit\n")
-	fmt.Println("  2. Validate your configuration")
-	fmt.Printf("     toske validate\n")
-	fmt.Println("  3. Backup your project files")
-	fmt.Printf("     toske backup --project <project-name>\n")
+	fmt.Printf(i18n.T("init.success")+"\n", configPath)
+	fmt.Println(i18n.T("init.nextSteps"))
+	fmt.Println(i18n.T("init.nextSteps.edit"))
+	fmt.Println(i18n.T("init.nextSteps.editCmd"))
+	fmt.Println(i18n.T("init.nextSteps.validate"))
+	fmt.Println(i18n.T("init.nextSteps.validateCmd"))
+	fmt.Println(i18n.T("init.nextSteps.backup"))
+	fmt.Println(i18n.T("init.nextSteps.backupCmd"))
 
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,6 +83,16 @@ func initConfig() {
 	// ja: 設定ファイルが見つかった場合は読み込む
 	// en: If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		configFile := viper.ConfigFileUsed()
+		fmt.Fprintln(os.Stderr, "Using config file:", configFile)
+
+		// ja: レガシーパスを使用している場合は移行を促す警告を表示
+		// en: Show migration warning if using legacy path
+		if isLegacyConfigPath(configFile) {
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, i18n.T("config.legacyWarning"))
+			fmt.Fprintln(os.Stderr, i18n.T("config.legacyWarningDetail"))
+			fmt.Fprintln(os.Stderr, "")
+		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/yk-lab/toske/i18n"
 	"github.com/yk-lab/toske/utils"
 )
 
@@ -16,7 +17,7 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "toske",
-	Short: "A brief description of your application",
+	Short: i18n.T("root.short"),
 	Long:  getHeroMessage(),
 	// Uncomment the following line if your bare application
 	// has an action associated with it:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,12 +14,14 @@ import (
 
 var cfgFile string
 
-// rootCmd represents the base command when called without any subcommands
+// ja: rootCmd は、サブコマンドが指定されなかった場合の基本コマンドを表します
+// en: rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "toske",
 	Short: i18n.T("root.short"),
 	Long:  getHeroMessage(),
-	// Uncomment the following line if your bare application
+	// ja: アクションが関連付けられている場合は、以下の行のコメントを解除してください
+	// en: Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
 }
@@ -33,7 +35,9 @@ func getHeroMessage() string {
 	return txt
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
+// ja: Execute は、すべての子コマンドを root コマンドに追加し、適切にフラグを設定します。
+// これは main.main() によって呼び出されます。rootCmd に対して一度だけ実行する必要があります。
+// en: Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	err := rootCmd.Execute()
@@ -45,36 +49,39 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	// Here you will define your flags and configuration settings.
+	// ja: ここでフラグと設定を定義します。
+	// Cobra は永続フラグをサポートしており、ここで定義された場合、アプリケーション全体でグローバルになります。
+	// en: Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.toske.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/toske/config.yml)")
 
-	// Cobra also supports local flags, which will only run
+	// ja: Cobra はローカルフラグもサポートしており、これはこのアクションが直接呼び出された場合にのみ実行されます。
+	// en: Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
-// initConfig reads in config file and ENV variables if set.
+// ja: initConfig は、設定ファイルと設定されている場合は環境変数を読み込みます。
+// en: initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	if cfgFile != "" {
-		// Use config file from the flag.
+		// ja: フラグから設定ファイルを使用する
+		// en: Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
 	} else {
-		// Find home directory.
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".toske" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName(".toske")
+		// ja: デフォルトの設定ファイルパスを使用する（TOSKE_CONFIG 環境変数やフォールバックを処理）
+		// en: Use default config path (handles TOSKE_CONFIG env var and fallback)
+		viper.SetConfigFile(getDefaultConfigPath())
 	}
 
-	viper.AutomaticEnv() // read in environment variables that match
+	// ja: 環境変数を自動的に読み込む
+	// en: read in environment variables that match
+	viper.AutomaticEnv()
 
-	// If a config file is found, read it in.
+	// ja: 設定ファイルが見つかった場合は読み込む
+	// en: If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -1,0 +1,90 @@
+package i18n
+
+import (
+	"os"
+	"strings"
+)
+
+// SupportedLanguages is the list of supported language codes
+var SupportedLanguages = []string{"en", "ja"}
+
+// currentLanguage holds the detected language
+var currentLanguage string
+
+func init() {
+	currentLanguage = detectLanguage()
+}
+
+// detectLanguage detects the user's preferred language from environment variables
+// Priority: TOSKE_LANG > LANG > LC_ALL > default (en)
+func detectLanguage() string {
+	// Check TOSKE_LANG first (tool-specific override)
+	if lang := os.Getenv("TOSKE_LANG"); lang != "" {
+		return normalizeLanguage(lang)
+	}
+
+	// Check LANG environment variable
+	if lang := os.Getenv("LANG"); lang != "" {
+		return normalizeLanguage(lang)
+	}
+
+	// Check LC_ALL as fallback
+	if lang := os.Getenv("LC_ALL"); lang != "" {
+		return normalizeLanguage(lang)
+	}
+
+	// Default to English
+	return "en"
+}
+
+// normalizeLanguage extracts the language code from locale string
+// e.g., "ja_JP.UTF-8" -> "ja", "en_US" -> "en"
+func normalizeLanguage(locale string) string {
+	// Split by underscore or dot
+	parts := strings.FieldsFunc(locale, func(r rune) bool {
+		return r == '_' || r == '.' || r == '-'
+	})
+
+	if len(parts) == 0 {
+		return "en"
+	}
+
+	lang := strings.ToLower(parts[0])
+
+	// Check if the language is supported
+	for _, supported := range SupportedLanguages {
+		if lang == supported {
+			return lang
+		}
+	}
+
+	// Default to English if not supported
+	return "en"
+}
+
+// T returns the translated message for the given key
+// If the key is not found in the current language, it falls back to English
+func T(key string) string {
+	// Try to get message in current language
+	if msg, ok := messages[currentLanguage][key]; ok {
+		return msg
+	}
+
+	// Fallback to English
+	if msg, ok := messages["en"][key]; ok {
+		return msg
+	}
+
+	// If not found at all, return the key itself as a fallback
+	return key
+}
+
+// GetLanguage returns the current language code
+func GetLanguage() string {
+	return currentLanguage
+}
+
+// SetLanguage sets the current language (useful for testing)
+func SetLanguage(lang string) {
+	currentLanguage = normalizeLanguage(lang)
+}

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -1,0 +1,62 @@
+package i18n
+
+// messages contains all translated messages
+// Structure: messages[language][key] = translated text
+var messages = map[string]map[string]string{
+	"en": {
+		// Root command
+		"root.short": "A brief description of your application",
+
+		// Init command
+		"init.short": "Initialize configuration file",
+		"init.long": `Initialize creates a new configuration file at the default location.
+The default path is ~/.config/toske/config.yml
+
+You can override the default path by setting the TOSKE_CONFIG environment variable.`,
+		"init.fileExists":          "Configuration file already exists at: %s",
+		"init.overwritePrompt":     "Do you want to overwrite it? [y/N]: ",
+		"init.cancelled":           "Initialization cancelled.",
+		"init.createDirError":      "failed to create config directory: %w",
+		"init.writeFileError":      "failed to write config file: %w",
+		"init.readInputError":      "failed to read input: %w",
+		"init.success":             "✓ Configuration file created successfully at: %s",
+		"init.nextSteps":           "\nNext steps:",
+		"init.nextSteps.edit":      "  1. Edit the configuration file to add your projects",
+		"init.nextSteps.editCmd":   "     toske edit",
+		"init.nextSteps.validate":  "  2. Validate your configuration",
+		"init.nextSteps.validateCmd": "     toske validate",
+		"init.nextSteps.backup":    "  3. Backup your project files",
+		"init.nextSteps.backupCmd": "     toske backup --project <project-name>",
+
+		// Common
+		"common.error": "Error: %v",
+	},
+	"ja": {
+		// Root command
+		"root.short": "アプリケーションの簡単な説明",
+
+		// Init command
+		"init.short": "設定ファイルを初期化",
+		"init.long": `デフォルトの場所に新しい設定ファイルを作成します。
+デフォルトパス: ~/.config/toske/config.yml
+
+TOSKE_CONFIG 環境変数を設定することで、デフォルトパスを上書きできます。`,
+		"init.fileExists":          "設定ファイルは既に存在します: %s",
+		"init.overwritePrompt":     "上書きしますか？ [y/N]: ",
+		"init.cancelled":           "初期化をキャンセルしました。",
+		"init.createDirError":      "設定ディレクトリの作成に失敗しました: %w",
+		"init.writeFileError":      "設定ファイルの書き込みに失敗しました: %w",
+		"init.readInputError":      "入力の読み取りに失敗しました: %w",
+		"init.success":             "✓ 設定ファイルを正常に作成しました: %s",
+		"init.nextSteps":           "\n次のステップ:",
+		"init.nextSteps.edit":      "  1. 設定ファイルを編集してプロジェクトを追加",
+		"init.nextSteps.editCmd":   "     toske edit",
+		"init.nextSteps.validate":  "  2. 設定ファイルを検証",
+		"init.nextSteps.validateCmd": "     toske validate",
+		"init.nextSteps.backup":    "  3. プロジェクトファイルをバックアップ",
+		"init.nextSteps.backupCmd": "     toske backup --project <プロジェクト名>",
+
+		// Common
+		"common.error": "エラー: %v",
+	},
+}

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -28,6 +28,10 @@ You can override the default path by setting the TOSKE_CONFIG environment variab
 		"init.nextSteps.backup":    "  3. Backup your project files",
 		"init.nextSteps.backupCmd": "     toske backup --project <project-name>",
 
+		// Config
+		"config.legacyWarning":       "⚠️  WARNING: You are using a legacy configuration file location.",
+		"config.legacyWarningDetail": "   Please migrate to ~/.config/toske/config.yml by running: mv ~/.toske.yaml ~/.config/toske/config.yml",
+
 		// Common
 		"common.error": "Error: %v",
 	},
@@ -55,6 +59,10 @@ TOSKE_CONFIG 環境変数を設定することで、デフォルトパスを上�
 		"init.nextSteps.validateCmd": "     toske validate",
 		"init.nextSteps.backup":    "  3. プロジェクトファイルをバックアップ",
 		"init.nextSteps.backupCmd": "     toske backup --project <プロジェクト名>",
+
+		// Config
+		"config.legacyWarning":       "⚠️  警告: レガシーの設定ファイル位置を使用しています。",
+		"config.legacyWarningDetail": "   次のコマンドで ~/.config/toske/config.yml に移行してください: mv ~/.toske.yaml ~/.config/toske/config.yml",
 
 		// Common
 		"common.error": "エラー: %v",


### PR DESCRIPTION
変更内容:

- ✅ toske init コマンドの実装（115行）
- ✅ 英語・日本語の多言語対応（i18nパッケージ）
- ✅ 環境変数による言語切り替え（LANG, TOSKE_LANG）
- ✅ 設定ファイルテンプレートの自動生成
- ✅ 上書き確認機能