### PR TITLE
Implement help command functionality

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yk-lab/toske/i18n"
+)
+
+// ja: helpCmd は help コマンドを表します
+// en: helpCmd represents the help command
+var helpCmd = &cobra.Command{
+	Use:   "help [command]",
+	Short: i18n.T("help.short"),
+	Long:  i18n.T("help.long"),
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			// ja: 引数がない場合は、すべてのコマンドのヘルプを表示
+			// en: Display help for all commands if no arguments
+			showAllCommandsHelp(cmd)
+		} else {
+			// ja: 特定のコマンドのヘルプを表示
+			// en: Display help for a specific command
+			showCommandHelp(cmd, args[0])
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(helpCmd)
+}
+
+// ja: showAllCommandsHelp はすべてのコマンドのヘルプを表示します
+// en: showAllCommandsHelp displays help for all commands
+func showAllCommandsHelp(cmd *cobra.Command) {
+	root := cmd.Root()
+
+	// ja: 使用法を表示
+	// en: Display usage
+	fmt.Printf("%s\n", i18n.T("help.usage"))
+	fmt.Printf("  %s\n\n", root.UseLine())
+
+	// ja: 説明を表示
+	// en: Display description
+	if root.Long != "" {
+		fmt.Printf("%s\n\n", root.Long)
+	} else if root.Short != "" {
+		fmt.Printf("%s\n\n", root.Short)
+	}
+
+	// ja: 利用可能なコマンドを表示
+	// en: Display available commands
+	fmt.Printf("%s\n", i18n.T("help.availableCommands"))
+
+	commands := root.Commands()
+	if len(commands) > 0 {
+		maxLen := 0
+		for _, c := range commands {
+			if !c.IsAvailableCommand() || c.Hidden {
+				continue
+			}
+			if len(c.Name()) > maxLen {
+				maxLen = len(c.Name())
+			}
+		}
+
+		for _, c := range commands {
+			if !c.IsAvailableCommand() || c.Hidden {
+				continue
+			}
+			fmt.Printf("  %-*s  %s\n", maxLen, c.Name(), c.Short)
+		}
+	}
+
+	// ja: フラグを表示
+	// en: Display flags
+	if root.HasAvailableFlags() {
+		fmt.Printf("\n%s\n", i18n.T("help.flags"))
+		fmt.Printf("%s", root.Flags().FlagUsages())
+	}
+
+	// ja: 追加のヘルプ情報を表示
+	// en: Display additional help information
+	fmt.Printf("%s\n", i18n.T("help.additionalHelp"))
+}
+
+// ja: showCommandHelp は特定のコマンドのヘルプを表示します
+// en: showCommandHelp displays help for a specific command
+func showCommandHelp(cmd *cobra.Command, commandName string) {
+	root := cmd.Root()
+
+	// ja: 指定されたコマンドを検索
+	// en: Find the specified command
+	var targetCmd *cobra.Command
+	for _, c := range root.Commands() {
+		if c.Name() == commandName || contains(c.Aliases, commandName) {
+			targetCmd = c
+			break
+		}
+	}
+
+	if targetCmd == nil {
+		fmt.Printf("Unknown command '%s'\n", commandName)
+		fmt.Printf("%s\n", i18n.T("help.additionalHelp"))
+		return
+	}
+
+	// ja: コマンドのヘルプを表示
+	// en: Display command help
+	targetCmd.Help()
+}
+
+// ja: contains は文字列のスライスに指定された文字列が含まれているかチェックします
+// en: contains checks if a string slice contains a specified string
+func contains(slice []string, str string) bool {
+	for _, s := range slice {
+		if strings.EqualFold(s, str) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -101,14 +102,17 @@ func showCommandHelp(cmd *cobra.Command, commandName string) {
 	}
 
 	if targetCmd == nil {
-		fmt.Printf("Unknown command '%s'\n", commandName)
+		fmt.Printf(i18n.T("help.unknownCommand")+"\n", commandName)
 		fmt.Printf("%s\n", i18n.T("help.additionalHelp"))
 		return
 	}
 
 	// ja: コマンドのヘルプを表示
 	// en: Display command help
-	targetCmd.Help()
+	if err := targetCmd.Help(); err != nil {
+		fmt.Fprintf(os.Stderr, i18n.T("help.displayError")+"\n", err)
+		os.Exit(1)
+	}
 }
 
 // ja: contains は文字列のスライスに指定された文字列が含まれているかチェックします

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,13 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	// ja: デフォルトの help コマンドを無効にして、カスタム help コマンドを使用
+	// en: Disable the default help command and use our custom help command
+	rootCmd.SetHelpCommand(&cobra.Command{
+		Use:    "no-help",
+		Hidden: true,
+	})
+
 	// ja: ここでフラグと設定を定義します。
 	// Cobra は永続フラグをサポートしており、ここで定義された場合、アプリケーション全体でグローバルになります。
 	// en: Here you will define your flags and configuration settings.

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -17,6 +17,8 @@ Use 'toske help [command]' to get detailed information about a specific command.
 		"help.usage":             "Usage:",
 		"help.examples":          "Examples:",
 		"help.additionalHelp":    "\nUse \"toske [command] --help\" for more information about a command.",
+		"help.unknownCommand":    "Unknown command '%s'",
+		"help.displayError":      "Error displaying help: %v",
 
 		// Init command
 		"init.short": "Initialize configuration file",
@@ -60,6 +62,8 @@ You can override the default path by setting the TOSKE_CONFIG environment variab
 		"help.usage":             "使用法:",
 		"help.examples":          "例:",
 		"help.additionalHelp":    "\nコマンドの詳細情報は \"toske [コマンド] --help\" を使用してください。",
+		"help.unknownCommand":    "不明なコマンド '%s'",
+		"help.displayError":      "ヘルプの表示エラー: %v",
 
 		// Init command
 		"init.short": "設定ファイルを初期化",

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -7,6 +7,17 @@ var messages = map[string]map[string]string{
 		// Root command
 		"root.short": "A brief description of your application",
 
+		// Help command
+		"help.short": "Display help information about commands",
+		"help.long": `Display detailed help information about available commands and their usage.
+
+Use 'toske help [command]' to get detailed information about a specific command.`,
+		"help.availableCommands": "Available Commands:",
+		"help.flags":             "Flags:",
+		"help.usage":             "Usage:",
+		"help.examples":          "Examples:",
+		"help.additionalHelp":    "\nUse \"toske [command] --help\" for more information about a command.",
+
 		// Init command
 		"init.short": "Initialize configuration file",
 		"init.long": `Initialize creates a new configuration file at the default location.
@@ -38,6 +49,17 @@ You can override the default path by setting the TOSKE_CONFIG environment variab
 	"ja": {
 		// Root command
 		"root.short": "アプリケーションの簡単な説明",
+
+		// Help command
+		"help.short": "コマンドのヘルプ情報を表示",
+		"help.long": `利用可能なコマンドとその使用方法の詳細なヘルプ情報を表示します。
+
+特定のコマンドの詳細情報を取得するには 'toske help [コマンド]' を使用してください。`,
+		"help.availableCommands": "利用可能なコマンド:",
+		"help.flags":             "フラグ:",
+		"help.usage":             "使用法:",
+		"help.examples":          "例:",
+		"help.additionalHelp":    "\nコマンドの詳細情報は \"toske [コマンド] --help\" を使用してください。",
 
 		// Init command
 		"init.short": "設定ファイルを初期化",


### PR DESCRIPTION
Implemented a custom help command that supports both English and Japanese languages:
- Added cmd/help.go with custom help command implementation
- Updated i18n/messages.go with help command translations (en/ja)
- Modified cmd/root.go to disable default Cobra help command to avoid duplication
- Help command displays all available commands and their descriptions
- Supports specific command help with 'toske help [command]'
- Fully integrated with existing i18n system