### PR TITLE
Implement version command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,10 +7,22 @@ import (
 	"github.com/yk-lab/toske/i18n"
 )
 
-// Version is the current version of toske
-// This can be overridden at build time using ldflags:
-// go build -ldflags "-X github.com/yk-lab/toske/cmd.Version=0.1.0"
-var Version = "dev"
+var (
+	// Version is the current version of toske
+	// This can be overridden at build time using ldflags:
+	// go build -ldflags "-X github.com/yk-lab/toske/cmd.Version=0.1.0"
+	Version = "dev"
+
+	// Commit is the git commit hash
+	// This can be set at build time using ldflags:
+	// go build -ldflags "-X github.com/yk-lab/toske/cmd.Commit=$(git rev-parse HEAD)"
+	Commit = "unknown"
+
+	// BuildDate is the build date
+	// This can be set at build time using ldflags:
+	// go build -ldflags "-X github.com/yk-lab/toske/cmd.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	BuildDate = "unknown"
+)
 
 // ja: versionCmd は version コマンドを表します
 // en: versionCmd represents the version command
@@ -19,10 +31,18 @@ var versionCmd = &cobra.Command{
 	Short: i18n.T("version.short"),
 	Long:  i18n.T("version.long"),
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("toske version %s\n", Version)
+		short, _ := cmd.Flags().GetBool("short")
+		if short {
+			fmt.Println(Version)
+		} else {
+			fmt.Printf("toske version %s\n", Version)
+			fmt.Printf("  commit: %s\n", Commit)
+			fmt.Printf("  built:  %s\n", BuildDate)
+		}
 	},
 }
 
 func init() {
+	versionCmd.Flags().Bool("short", false, i18n.T("version.flag.short"))
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,9 @@ import (
 )
 
 // Version is the current version of toske
-const Version = "0.1.0"
+// This can be overridden at build time using ldflags:
+// go build -ldflags "-X github.com/yk-lab/toske/cmd.Version=0.1.0"
+var Version = "dev"
 
 // ja: versionCmd は version コマンドを表します
 // en: versionCmd represents the version command

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/yk-lab/toske/i18n"
+)
+
+// Version is the current version of toske
+const Version = "0.1.0"
+
+// ja: versionCmd は version コマンドを表します
+// en: versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: i18n.T("version.short"),
+	Long:  i18n.T("version.long"),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("toske version %s\n", Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -15,8 +15,9 @@ The default path is ~/.config/toske/config.yml
 You can override the default path by setting the TOSKE_CONFIG environment variable.`,
 
 		// Version command
-		"version.short": "Print the version number of toske",
-		"version.long":  "Print the version number of toske",
+		"version.short":      "Print the version number of toske",
+		"version.long":       "Print the version number of toske along with build information",
+		"version.flag.short": "Print only the version number",
 		"init.fileExists":          "Configuration file already exists at: %s",
 		"init.overwritePrompt":     "Do you want to overwrite it? [y/N]: ",
 		"init.cancelled":           "Initialization cancelled.",
@@ -51,8 +52,9 @@ You can override the default path by setting the TOSKE_CONFIG environment variab
 TOSKE_CONFIG 環境変数を設定することで、デフォルトパスを上書きできます。`,
 
 		// Version command
-		"version.short": "toske のバージョン番号を表示",
-		"version.long":  "toske のバージョン番号を表示します",
+		"version.short":      "toske のバージョン番号を表示",
+		"version.long":       "toske のバージョン番号とビルド情報を表示します",
+		"version.flag.short": "バージョン番号のみを表示",
 		"init.fileExists":          "設定ファイルは既に存在します: %s",
 		"init.overwritePrompt":     "上書きしますか？ [y/N]: ",
 		"init.cancelled":           "初期化をキャンセルしました。",

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -13,6 +13,10 @@ var messages = map[string]map[string]string{
 The default path is ~/.config/toske/config.yml
 
 You can override the default path by setting the TOSKE_CONFIG environment variable.`,
+
+		// Version command
+		"version.short": "Print the version number of toske",
+		"version.long":  "Print the version number of toske",
 		"init.fileExists":          "Configuration file already exists at: %s",
 		"init.overwritePrompt":     "Do you want to overwrite it? [y/N]: ",
 		"init.cancelled":           "Initialization cancelled.",
@@ -45,6 +49,10 @@ You can override the default path by setting the TOSKE_CONFIG environment variab
 デフォルトパス: ~/.config/toske/config.yml
 
 TOSKE_CONFIG 環境変数を設定することで、デフォルトパスを上書きできます。`,
+
+		// Version command
+		"version.short": "toske のバージョン番号を表示",
+		"version.long":  "toske のバージョン番号を表示します",
 		"init.fileExists":          "設定ファイルは既に存在します: %s",
 		"init.overwritePrompt":     "上書きしますか？ [y/N]: ",
 		"init.cancelled":           "初期化をキャンセルしました。",


### PR DESCRIPTION
Add version command that displays the current version of toske. This includes support for both English and Japanese localization.

- Created cmd/version.go with version constant (0.1.0)
- Added i18n messages for version command in both English and Japanese
- Version command follows the same pattern as existing commands using Cobra