### PR TITLE
Implement edit command functionality

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/yk-lab/toske/i18n"
@@ -53,7 +54,10 @@ func runEdit() error {
 	// en: Open config file in editor
 	fmt.Printf(i18n.T("edit.openingEditor")+"\n", editor)
 
-	editorCmd := exec.Command(editor, configPath)
+	// ja: エディタコマンドをパースして引数を分離
+	// en: Parse editor command to separate arguments
+	editorParts := strings.Fields(editor)
+	editorCmd := exec.Command(editorParts[0], append(editorParts[1:], configPath)...)
 	editorCmd.Stdin = os.Stdin
 	editorCmd.Stdout = os.Stdout
 	editorCmd.Stderr = os.Stderr

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"github.com/yk-lab/toske/i18n"
+)
+
+// ja: editCmd は edit コマンドを表します
+// en: editCmd represents the edit command
+var editCmd = &cobra.Command{
+	Use:   "edit",
+	Short: i18n.T("edit.short"),
+	Long:  i18n.T("edit.long"),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runEdit(); err != nil {
+			fmt.Fprintf(os.Stderr, i18n.T("common.error")+"\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(editCmd)
+}
+
+func runEdit() error {
+	// ja: 設定ファイルパスを決定
+	// en: Determine config file path
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = getDefaultConfigPath()
+	}
+
+	// ja: 設定ファイルが存在するかチェック
+	// en: Check if config file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		msg := fmt.Sprintf(i18n.T("edit.noConfig"), configPath)
+		return fmt.Errorf("%s", msg)
+	}
+
+	// ja: エディタを決定
+	// en: Determine editor
+	editor := getEditor()
+	if editor == "" {
+		return fmt.Errorf("%s", i18n.T("edit.noEditor"))
+	}
+
+	// ja: エディタで設定ファイルを開く
+	// en: Open config file in editor
+	fmt.Printf(i18n.T("edit.openingEditor")+"\n", editor)
+
+	editorCmd := exec.Command(editor, configPath)
+	editorCmd.Stdin = os.Stdin
+	editorCmd.Stdout = os.Stdout
+	editorCmd.Stderr = os.Stderr
+
+	if err := editorCmd.Run(); err != nil {
+		msg := fmt.Sprintf(i18n.T("edit.editorError"), err)
+		return fmt.Errorf("%s", msg)
+	}
+
+	return nil
+}
+
+// ja: getEditor はユーザーの環境に応じたエディタを返します
+// en: getEditor returns the editor based on user's environment
+func getEditor() string {
+	// ja: EDITOR 環境変数をチェック
+	// en: Check EDITOR environment variable
+	if editor := os.Getenv("EDITOR"); editor != "" {
+		return editor
+	}
+
+	// ja: VISUAL 環境変数をチェック（代替手段）
+	// en: Check VISUAL environment variable (alternative)
+	if visual := os.Getenv("VISUAL"); visual != "" {
+		return visual
+	}
+
+	// ja: デフォルトエディタを順番に試す
+	// en: Try default editors in order
+	editors := []string{"vim", "vi", "nano"}
+	for _, editor := range editors {
+		if _, err := exec.LookPath(editor); err == nil {
+			return editor
+		}
+	}
+
+	return ""
+}

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -21,13 +21,21 @@ func hasDefaultEditor() bool {
 func TestGetEditor(t *testing.T) {
 	// ja: 元の環境変数を保存
 	// en: Save original environment variables
-	originalEditor := os.Getenv("EDITOR")
-	originalVisual := os.Getenv("VISUAL")
+	originalEditor, editorWasSet := os.LookupEnv("EDITOR")
+	originalVisual, visualWasSet := os.LookupEnv("VISUAL")
 	defer func() {
 		// ja: テスト後に環境変数を復元
 		// en: Restore environment variables after test
-		os.Setenv("EDITOR", originalEditor)
-		os.Setenv("VISUAL", originalVisual)
+		if editorWasSet {
+			os.Setenv("EDITOR", originalEditor)
+		} else {
+			os.Unsetenv("EDITOR")
+		}
+		if visualWasSet {
+			os.Setenv("VISUAL", originalVisual)
+		} else {
+			os.Unsetenv("VISUAL")
+		}
 	}()
 
 	tests := []struct {
@@ -95,11 +103,21 @@ func TestGetEditor(t *testing.T) {
 func TestGetEditorPriority(t *testing.T) {
 	// ja: 元の環境変数を保存
 	// en: Save original environment variables
-	originalEditor := os.Getenv("EDITOR")
-	originalVisual := os.Getenv("VISUAL")
+	originalEditor, editorWasSet := os.LookupEnv("EDITOR")
+	originalVisual, visualWasSet := os.LookupEnv("VISUAL")
 	defer func() {
-		os.Setenv("EDITOR", originalEditor)
-		os.Setenv("VISUAL", originalVisual)
+		// ja: テスト後に環境変数を復元
+		// en: Restore environment variables after test
+		if editorWasSet {
+			os.Setenv("EDITOR", originalEditor)
+		} else {
+			os.Unsetenv("EDITOR")
+		}
+		if visualWasSet {
+			os.Setenv("VISUAL", originalVisual)
+		} else {
+			os.Unsetenv("VISUAL")
+		}
 	}()
 
 	// ja: EDITOR と VISUAL の両方が設定されている場合、EDITOR が優先される
@@ -116,13 +134,21 @@ func TestGetEditorPriority(t *testing.T) {
 func TestGetEditorWithFlags(t *testing.T) {
 	// ja: 元の環境変数を保存
 	// en: Save original environment variables
-	originalEditor := os.Getenv("EDITOR")
-	originalVisual := os.Getenv("VISUAL")
+	originalEditor, editorWasSet := os.LookupEnv("EDITOR")
+	originalVisual, visualWasSet := os.LookupEnv("VISUAL")
 	defer func() {
 		// ja: テスト後に環境変数を復元
 		// en: Restore environment variables after test
-		os.Setenv("EDITOR", originalEditor)
-		os.Setenv("VISUAL", originalVisual)
+		if editorWasSet {
+			os.Setenv("EDITOR", originalEditor)
+		} else {
+			os.Unsetenv("EDITOR")
+		}
+		if visualWasSet {
+			os.Setenv("VISUAL", originalVisual)
+		} else {
+			os.Unsetenv("VISUAL")
+		}
 	}()
 
 	tests := []struct {

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetEditor(t *testing.T) {
+	// ja: 元の環境変数を保存
+	// en: Save original environment variables
+	originalEditor := os.Getenv("EDITOR")
+	originalVisual := os.Getenv("VISUAL")
+	defer func() {
+		// ja: テスト後に環境変数を復元
+		// en: Restore environment variables after test
+		os.Setenv("EDITOR", originalEditor)
+		os.Setenv("VISUAL", originalVisual)
+	}()
+
+	tests := []struct {
+		name          string
+		editorEnv     string
+		visualEnv     string
+		expectNonEmpty bool
+	}{
+		{
+			name:          "EDITOR environment variable is set",
+			editorEnv:     "emacs",
+			visualEnv:     "",
+			expectNonEmpty: true,
+		},
+		{
+			name:          "VISUAL environment variable is set",
+			editorEnv:     "",
+			visualEnv:     "nano",
+			expectNonEmpty: true,
+		},
+		{
+			name:          "Both environment variables are empty",
+			editorEnv:     "",
+			visualEnv:     "",
+			expectNonEmpty: true, // Should find default editor (vim/vi/nano)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ja: 環境変数を設定
+			// en: Set environment variables
+			os.Setenv("EDITOR", tt.editorEnv)
+			os.Setenv("VISUAL", tt.visualEnv)
+
+			// ja: エディタを取得
+			// en: Get editor
+			editor := getEditor()
+
+			if tt.expectNonEmpty && editor == "" {
+				t.Errorf("Expected non-empty editor, got empty string")
+			}
+
+			// ja: EDITOR が設定されている場合は、それが返されることを確認
+			// en: If EDITOR is set, verify it's returned
+			if tt.editorEnv != "" && editor != tt.editorEnv {
+				t.Errorf("Expected editor %s, got %s", tt.editorEnv, editor)
+			}
+
+			// ja: EDITOR が空で VISUAL が設定されている場合は、VISUAL が返されることを確認
+			// en: If EDITOR is empty and VISUAL is set, verify VISUAL is returned
+			if tt.editorEnv == "" && tt.visualEnv != "" && editor != tt.visualEnv {
+				t.Errorf("Expected editor %s, got %s", tt.visualEnv, editor)
+			}
+		})
+	}
+}
+
+func TestGetEditorPriority(t *testing.T) {
+	// ja: 元の環境変数を保存
+	// en: Save original environment variables
+	originalEditor := os.Getenv("EDITOR")
+	originalVisual := os.Getenv("VISUAL")
+	defer func() {
+		os.Setenv("EDITOR", originalEditor)
+		os.Setenv("VISUAL", originalVisual)
+	}()
+
+	// ja: EDITOR と VISUAL の両方が設定されている場合、EDITOR が優先される
+	// en: When both EDITOR and VISUAL are set, EDITOR takes priority
+	os.Setenv("EDITOR", "emacs")
+	os.Setenv("VISUAL", "nano")
+
+	editor := getEditor()
+	if editor != "emacs" {
+		t.Errorf("Expected EDITOR to take priority, got %s instead of emacs", editor)
+	}
+}

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -2,8 +2,21 @@ package cmd
 
 import (
 	"os"
+	"os/exec"
 	"testing"
 )
+
+// ja: hasDefaultEditor はデフォルトエディタが利用可能かチェックします
+// en: hasDefaultEditor checks if any default editor is available
+func hasDefaultEditor() bool {
+	editors := []string{"vim", "vi", "nano"}
+	for _, editor := range editors {
+		if _, err := exec.LookPath(editor); err == nil {
+			return true
+		}
+	}
+	return false
+}
 
 func TestGetEditor(t *testing.T) {
 	// ja: 元の環境変数を保存
@@ -45,6 +58,12 @@ func TestGetEditor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// ja: 両方の環境変数が空の場合、デフォルトエディタの存在をチェック
+			// en: If both environment variables are empty, check for default editor
+			if tt.editorEnv == "" && tt.visualEnv == "" && !hasDefaultEditor() {
+				t.Skip("Skipping test: no default editor (vim/vi/nano) found on system")
+			}
+
 			// ja: 環境変数を設定
 			// en: Set environment variables
 			os.Setenv("EDITOR", tt.editorEnv)

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -112,3 +112,61 @@ func TestGetEditorPriority(t *testing.T) {
 		t.Errorf("Expected EDITOR to take priority, got %s instead of emacs", editor)
 	}
 }
+
+func TestGetEditorWithFlags(t *testing.T) {
+	// ja: 元の環境変数を保存
+	// en: Save original environment variables
+	originalEditor := os.Getenv("EDITOR")
+	originalVisual := os.Getenv("VISUAL")
+	defer func() {
+		// ja: テスト後に環境変数を復元
+		// en: Restore environment variables after test
+		os.Setenv("EDITOR", originalEditor)
+		os.Setenv("VISUAL", originalVisual)
+	}()
+
+	tests := []struct {
+		name         string
+		editorEnv    string
+		visualEnv    string
+		expectedFull string
+	}{
+		{
+			name:         "EDITOR with flags",
+			editorEnv:    "code --wait",
+			visualEnv:    "",
+			expectedFull: "code --wait",
+		},
+		{
+			name:         "VISUAL with flags",
+			editorEnv:    "",
+			visualEnv:    "subl -w",
+			expectedFull: "subl -w",
+		},
+		{
+			name:         "EDITOR with multiple flags",
+			editorEnv:    "emacs -nw --no-splash",
+			visualEnv:    "",
+			expectedFull: "emacs -nw --no-splash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ja: 環境変数を設定
+			// en: Set environment variables
+			os.Setenv("EDITOR", tt.editorEnv)
+			os.Setenv("VISUAL", tt.visualEnv)
+
+			// ja: エディタを取得
+			// en: Get editor
+			editor := getEditor()
+
+			// ja: フラグ付きのエディタコマンドが正しく返されることを確認
+			// en: Verify that editor command with flags is returned correctly
+			if editor != tt.expectedFull {
+				t.Errorf("Expected editor %q, got %q", tt.expectedFull, editor)
+			}
+		})
+	}
+}

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -31,6 +31,14 @@ You can override the default path by setting the TOSKE_CONFIG environment variab
 		"version.short":      "Print the version number of toske",
 		"version.long":       "Print the version number of toske along with build information",
 		"version.flag.short": "Print only the version number",
+
+		// Edit command
+		"edit.short":         "Edit the configuration file",
+		"edit.long":          "Open the configuration file in your default editor.\nThe editor is determined by the EDITOR environment variable, or falls back to vi/vim/nano.",
+		"edit.noConfig":      "Configuration file does not exist: %s\nRun 'toske init' to create one.",
+		"edit.noEditor":      "No suitable editor found. Please set the EDITOR environment variable.",
+		"edit.editorError":   "Failed to open editor: %v",
+		"edit.openingEditor": "Opening configuration file in %s...",
 		"init.fileExists":          "Configuration file already exists at: %s",
 		"init.overwritePrompt":     "Do you want to overwrite it? [y/N]: ",
 		"init.cancelled":           "Initialization cancelled.",
@@ -81,6 +89,14 @@ TOSKE_CONFIG 環境変数を設定することで、デフォルトパスを上�
 		"version.short":      "toske のバージョン番号を表示",
 		"version.long":       "toske のバージョン番号とビルド情報を表示します",
 		"version.flag.short": "バージョン番号のみを表示",
+
+		// Edit command
+		"edit.short":         "設定ファイルを編集",
+		"edit.long":          "設定ファイルをデフォルトエディタで開きます。\nエディタは EDITOR 環境変数で決定されます。設定されていない場合は vi/vim/nano を使用します。",
+		"edit.noConfig":      "設定ファイルが存在しません: %s\n'toske init' を実行して作成してください。",
+		"edit.noEditor":      "適切なエディタが見つかりません。EDITOR 環境変数を設定してください。",
+		"edit.editorError":   "エディタの起動に失敗しました: %v",
+		"edit.openingEditor": "設定ファイルを %s で開いています...",
 		"init.fileExists":          "設定ファイルは既に存在します: %s",
 		"init.overwritePrompt":     "上書きしますか？ [y/N]: ",
 		"init.cancelled":           "初期化をキャンセルしました。",


### PR DESCRIPTION
Add edit command that allows users to edit their configuration file using their preferred editor. The command respects EDITOR and VISUAL environment variables, with fallback to common editors (vim, vi, nano).

Changes:
- Add edit command implementation in cmd/edit.go
- Add comprehensive tests for editor selection logic
- Add i18n messages for edit command (English and Japanese)
- Integrate edit command into root command structure

The edit command provides:
- Automatic config file detection
- Support for EDITOR/VISUAL environment variables
- Fallback to common editors if env vars not set
- User-friendly error messages when config doesn't exist