### PR TITLE
Implement validate command

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -55,8 +55,7 @@ func runValidate() error {
 	// ja: 設定ファイルが存在するかチェック
 	// en: Check if config file exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		msg := fmt.Sprintf(i18n.T("validate.noConfig"), configPath)
-		return fmt.Errorf("%s", msg)
+		return fmt.Errorf(i18n.T("validate.noConfig"), configPath)
 	}
 
 	fmt.Printf(i18n.T("validate.checking")+"\n", configPath)
@@ -67,16 +66,14 @@ func runValidate() error {
 	v.SetConfigFile(configPath)
 
 	if err := v.ReadInConfig(); err != nil {
-		msg := fmt.Sprintf(i18n.T("validate.readError"), err)
-		return fmt.Errorf("%s", msg)
+		return fmt.Errorf(i18n.T("validate.readError"), err)
 	}
 
 	// ja: 設定を構造体にアンマーシャル
 	// en: Unmarshal config into struct
 	var config Config
 	if err := v.Unmarshal(&config); err != nil {
-		msg := fmt.Sprintf(i18n.T("validate.parseError"), err)
-		return fmt.Errorf("%s", msg)
+		return fmt.Errorf(i18n.T("validate.parseError"), err)
 	}
 
 	// ja: 設定を検証
@@ -127,36 +124,31 @@ func validateProject(project *Project, index int, projectNames map[string]bool) 
 	// ja: プロジェクト名の検証
 	// en: Validate project name
 	if project.Name == "" {
-		msg := fmt.Sprintf(i18n.T("validate.error.projectNoName"), projectNum)
-		return fmt.Errorf("%s", msg)
+		return fmt.Errorf(i18n.T("validate.error.projectNoName"), projectNum)
 	}
 
 	// ja: 重複した名前のチェック
 	// en: Check for duplicate names
 	if projectNames[project.Name] {
-		msg := fmt.Sprintf(i18n.T("validate.error.duplicateName"), project.Name)
-		return fmt.Errorf("%s", msg)
+		return fmt.Errorf(i18n.T("validate.error.duplicateName"), project.Name)
 	}
 
 	// ja: リポジトリURLの検証
 	// en: Validate repository URL
 	if project.Repo == "" {
-		msg := fmt.Sprintf(i18n.T("validate.error.projectNoRepo"), project.Name)
-		return fmt.Errorf("%s", msg)
+		return fmt.Errorf(i18n.T("validate.error.projectNoRepo"), project.Name)
 	}
 
 	// ja: ブランチ名の検証
 	// en: Validate branch name
 	if project.Branch == "" {
-		msg := fmt.Sprintf(i18n.T("validate.error.projectNoBranch"), project.Name)
-		return fmt.Errorf("%s", msg)
+		return fmt.Errorf(i18n.T("validate.error.projectNoBranch"), project.Name)
 	}
 
 	// ja: backup_retention の検証（0以上である必要がある）
 	// en: Validate backup_retention (must be >= 0)
 	if project.BackupRetention < 0 {
-		msg := fmt.Sprintf(i18n.T("validate.error.invalidRetention"), project.Name, project.BackupRetention)
-		return fmt.Errorf("%s", msg)
+		return fmt.Errorf(i18n.T("validate.error.invalidRetention"), project.Name, project.BackupRetention)
 	}
 
 	return nil

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/yk-lab/toske/i18n"
+)
+
+// ja: Config は設定ファイルの構造を表します
+// en: Config represents the structure of the configuration file
+type Config struct {
+	Version  string    `mapstructure:"version"`
+	Projects []Project `mapstructure:"projects"`
+}
+
+// ja: Project はプロジェクト設定を表します
+// en: Project represents a project configuration
+type Project struct {
+	Name            string   `mapstructure:"name"`
+	Repo            string   `mapstructure:"repo"`
+	Branch          string   `mapstructure:"branch"`
+	BackupPaths     []string `mapstructure:"backup_paths"`
+	BackupRetention int      `mapstructure:"backup_retention"`
+}
+
+// ja: validateCmd は validate コマンドを表します
+// en: validateCmd represents the validate command
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: i18n.T("validate.short"),
+	Long:  i18n.T("validate.long"),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runValidate(); err != nil {
+			fmt.Fprintf(os.Stderr, i18n.T("common.error")+"\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}
+
+func runValidate() error {
+	// ja: 設定ファイルパスを決定
+	// en: Determine config file path
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = getDefaultConfigPath()
+	}
+
+	// ja: 設定ファイルが存在するかチェック
+	// en: Check if config file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		msg := fmt.Sprintf(i18n.T("validate.noConfig"), configPath)
+		return fmt.Errorf("%s", msg)
+	}
+
+	fmt.Printf(i18n.T("validate.checking")+"\n", configPath)
+
+	// ja: 設定ファイルを読み込む
+	// en: Load configuration file
+	v := viper.New()
+	v.SetConfigFile(configPath)
+
+	if err := v.ReadInConfig(); err != nil {
+		msg := fmt.Sprintf(i18n.T("validate.readError"), err)
+		return fmt.Errorf("%s", msg)
+	}
+
+	// ja: 設定を構造体にアンマーシャル
+	// en: Unmarshal config into struct
+	var config Config
+	if err := v.Unmarshal(&config); err != nil {
+		msg := fmt.Sprintf(i18n.T("validate.parseError"), err)
+		return fmt.Errorf("%s", msg)
+	}
+
+	// ja: 設定を検証
+	// en: Validate configuration
+	if err := validateConfig(&config); err != nil {
+		return err
+	}
+
+	fmt.Println(i18n.T("validate.success"))
+	fmt.Printf(i18n.T("validate.projectCount")+"\n", len(config.Projects))
+
+	return nil
+}
+
+// ja: validateConfig は設定ファイルの内容を検証します
+// en: validateConfig validates the contents of the configuration
+func validateConfig(config *Config) error {
+	// ja: バージョンの検証
+	// en: Validate version
+	if config.Version == "" {
+		return fmt.Errorf("%s", i18n.T("validate.error.noVersion"))
+	}
+
+	// ja: プロジェクトの検証
+	// en: Validate projects
+	if len(config.Projects) == 0 {
+		return fmt.Errorf("%s", i18n.T("validate.error.noProjects"))
+	}
+
+	// ja: 各プロジェクトを検証
+	// en: Validate each project
+	projectNames := make(map[string]bool)
+	for i, project := range config.Projects {
+		if err := validateProject(&project, i, projectNames); err != nil {
+			return err
+		}
+		projectNames[project.Name] = true
+	}
+
+	return nil
+}
+
+// ja: validateProject は個々のプロジェクト設定を検証します
+// en: validateProject validates an individual project configuration
+func validateProject(project *Project, index int, projectNames map[string]bool) error {
+	projectNum := index + 1
+
+	// ja: プロジェクト名の検証
+	// en: Validate project name
+	if project.Name == "" {
+		msg := fmt.Sprintf(i18n.T("validate.error.projectNoName"), projectNum)
+		return fmt.Errorf("%s", msg)
+	}
+
+	// ja: 重複した名前のチェック
+	// en: Check for duplicate names
+	if projectNames[project.Name] {
+		msg := fmt.Sprintf(i18n.T("validate.error.duplicateName"), project.Name)
+		return fmt.Errorf("%s", msg)
+	}
+
+	// ja: リポジトリURLの検証
+	// en: Validate repository URL
+	if project.Repo == "" {
+		msg := fmt.Sprintf(i18n.T("validate.error.projectNoRepo"), project.Name)
+		return fmt.Errorf("%s", msg)
+	}
+
+	// ja: ブランチ名の検証
+	// en: Validate branch name
+	if project.Branch == "" {
+		msg := fmt.Sprintf(i18n.T("validate.error.projectNoBranch"), project.Name)
+		return fmt.Errorf("%s", msg)
+	}
+
+	// ja: backup_retention の検証（0以上である必要がある）
+	// en: Validate backup_retention (must be >= 0)
+	if project.BackupRetention < 0 {
+		msg := fmt.Sprintf(i18n.T("validate.error.invalidRetention"), project.Name, project.BackupRetention)
+		return fmt.Errorf("%s", msg)
+	}
+
+	return nil
+}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -1,0 +1,360 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *Config
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid config",
+			config: &Config{
+				Version: "1.0.0",
+				Projects: []Project{
+					{
+						Name:            "test-project",
+						Repo:            "git@github.com:user/repo.git",
+						Branch:          "main",
+						BackupPaths:     []string{".env"},
+						BackupRetention: 3,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "missing version",
+			config: &Config{
+				Projects: []Project{
+					{
+						Name:   "test-project",
+						Repo:   "git@github.com:user/repo.git",
+						Branch: "main",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "no projects",
+			config: &Config{
+				Version:  "1.0.0",
+				Projects: []Project{},
+			},
+			expectError: true,
+		},
+		{
+			name: "project without name",
+			config: &Config{
+				Version: "1.0.0",
+				Projects: []Project{
+					{
+						Repo:   "git@github.com:user/repo.git",
+						Branch: "main",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "project without repo",
+			config: &Config{
+				Version: "1.0.0",
+				Projects: []Project{
+					{
+						Name:   "test-project",
+						Branch: "main",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "project without branch",
+			config: &Config{
+				Version: "1.0.0",
+				Projects: []Project{
+					{
+						Name: "test-project",
+						Repo: "git@github.com:user/repo.git",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "duplicate project names",
+			config: &Config{
+				Version: "1.0.0",
+				Projects: []Project{
+					{
+						Name:   "test-project",
+						Repo:   "git@github.com:user/repo1.git",
+						Branch: "main",
+					},
+					{
+						Name:   "test-project",
+						Repo:   "git@github.com:user/repo2.git",
+						Branch: "main",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "negative backup retention",
+			config: &Config{
+				Version: "1.0.0",
+				Projects: []Project{
+					{
+						Name:            "test-project",
+						Repo:            "git@github.com:user/repo.git",
+						Branch:          "main",
+						BackupRetention: -1,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "multiple valid projects",
+			config: &Config{
+				Version: "1.0.0",
+				Projects: []Project{
+					{
+						Name:            "project1",
+						Repo:            "git@github.com:user/repo1.git",
+						Branch:          "main",
+						BackupPaths:     []string{".env"},
+						BackupRetention: 3,
+					},
+					{
+						Name:            "project2",
+						Repo:            "https://github.com/user/repo2.git",
+						Branch:          "develop",
+						BackupPaths:     []string{".env", "db/"},
+						BackupRetention: 5,
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(tt.config)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateProject(t *testing.T) {
+	tests := []struct {
+		name         string
+		project      *Project
+		index        int
+		projectNames map[string]bool
+		expectError  bool
+	}{
+		{
+			name: "valid project",
+			project: &Project{
+				Name:            "test-project",
+				Repo:            "git@github.com:user/repo.git",
+				Branch:          "main",
+				BackupPaths:     []string{".env"},
+				BackupRetention: 3,
+			},
+			index:        0,
+			projectNames: make(map[string]bool),
+			expectError:  false,
+		},
+		{
+			name: "project without name",
+			project: &Project{
+				Repo:   "git@github.com:user/repo.git",
+				Branch: "main",
+			},
+			index:        0,
+			projectNames: make(map[string]bool),
+			expectError:  true,
+		},
+		{
+			name: "duplicate project name",
+			project: &Project{
+				Name:   "test-project",
+				Repo:   "git@github.com:user/repo.git",
+				Branch: "main",
+			},
+			index: 0,
+			projectNames: map[string]bool{
+				"test-project": true,
+			},
+			expectError: true,
+		},
+		{
+			name: "project without repo",
+			project: &Project{
+				Name:   "test-project",
+				Branch: "main",
+			},
+			index:        0,
+			projectNames: make(map[string]bool),
+			expectError:  true,
+		},
+		{
+			name: "project without branch",
+			project: &Project{
+				Name: "test-project",
+				Repo: "git@github.com:user/repo.git",
+			},
+			index:        0,
+			projectNames: make(map[string]bool),
+			expectError:  true,
+		},
+		{
+			name: "negative backup retention",
+			project: &Project{
+				Name:            "test-project",
+				Repo:            "git@github.com:user/repo.git",
+				Branch:          "main",
+				BackupRetention: -1,
+			},
+			index:        0,
+			projectNames: make(map[string]bool),
+			expectError:  true,
+		},
+		{
+			name: "zero backup retention (valid)",
+			project: &Project{
+				Name:            "test-project",
+				Repo:            "git@github.com:user/repo.git",
+				Branch:          "main",
+				BackupRetention: 0,
+			},
+			index:        0,
+			projectNames: make(map[string]bool),
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProject(tt.project, tt.index, tt.projectNames)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		configData  string
+		expectError bool
+	}{
+		{
+			name: "valid config",
+			configData: `version: 1.0.0
+projects:
+  - name: sample-project
+    repo: git@github.com:user/sample-project.git
+    branch: main
+    backup_paths:
+      - .env
+      - db.sqlite3
+    backup_retention: 3
+`,
+			expectError: false,
+		},
+		{
+			name: "invalid yaml",
+			configData: `version: 1.0.0
+projects:
+  - name: sample-project
+    repo: git@github.com:user/sample-project.git
+    branch: main
+    backup_paths:
+      - .env
+      - db.sqlite3
+    backup_retention: 3
+  invalid yaml here
+`,
+			expectError: true,
+		},
+		{
+			name: "missing required fields",
+			configData: `version: 1.0.0
+projects:
+  - name: sample-project
+    backup_paths:
+      - .env
+`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary config file
+			tempDir := t.TempDir()
+			configPath := filepath.Join(tempDir, "config.yml")
+
+			if err := os.WriteFile(configPath, []byte(tt.configData), 0644); err != nil {
+				t.Fatalf("Failed to create test config file: %v", err)
+			}
+
+			// Set cfgFile to use our temporary config
+			originalCfgFile := cfgFile
+			cfgFile = configPath
+			defer func() {
+				cfgFile = originalCfgFile
+			}()
+
+			// Run validate
+			err := runValidate()
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunValidateNoConfig(t *testing.T) {
+	// Create temporary directory without config file
+	tempDir := t.TempDir()
+	nonExistentPath := filepath.Join(tempDir, "nonexistent.yml")
+
+	// Set cfgFile to non-existent path
+	originalCfgFile := cfgFile
+	cfgFile = nonExistentPath
+	defer func() {
+		cfgFile = originalCfgFile
+	}()
+
+	// Run validate - should fail because config doesn't exist
+	err := runValidate()
+	if err == nil {
+		t.Errorf("Expected error for non-existent config file but got nil")
+	}
+}

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -54,6 +54,23 @@ You can override the default path by setting the TOSKE_CONFIG environment variab
 		"init.nextSteps.backup":    "  3. Backup your project files",
 		"init.nextSteps.backupCmd": "     toske backup --project <project-name>",
 
+		// Validate command
+		"validate.short":                    "Validate the configuration file",
+		"validate.long":                     "Validate checks the configuration file for syntax errors and ensures all required fields are present.",
+		"validate.noConfig":                 "Configuration file does not exist: %s\nRun 'toske init' to create one.",
+		"validate.checking":                 "Checking configuration file: %s",
+		"validate.readError":                "Failed to read configuration file: %v",
+		"validate.parseError":               "Failed to parse configuration file: %v",
+		"validate.success":                  "✓ Configuration file is valid!",
+		"validate.projectCount":             "  Found %d project(s) configured",
+		"validate.error.noVersion":          "Configuration error: 'version' field is required",
+		"validate.error.noProjects":         "Configuration error: at least one project must be defined",
+		"validate.error.projectNoName":      "Configuration error: project #%d is missing the 'name' field",
+		"validate.error.duplicateName":      "Configuration error: duplicate project name '%s'",
+		"validate.error.projectNoRepo":      "Configuration error: project '%s' is missing the 'repo' field",
+		"validate.error.projectNoBranch":    "Configuration error: project '%s' is missing the 'branch' field",
+		"validate.error.invalidRetention":   "Configuration error: project '%s' has invalid backup_retention value: %d (must be >= 0)",
+
 		// Config
 		"config.legacyWarning":       "⚠️  WARNING: You are using a legacy configuration file location.",
 		"config.legacyWarningDetail": "   Please migrate to ~/.config/toske/config.yml by running: mv ~/.toske.yaml ~/.config/toske/config.yml",
@@ -111,6 +128,23 @@ TOSKE_CONFIG 環境変数を設定することで、デフォルトパスを上�
 		"init.nextSteps.validateCmd": "     toske validate",
 		"init.nextSteps.backup":    "  3. プロジェクトファイルをバックアップ",
 		"init.nextSteps.backupCmd": "     toske backup --project <プロジェクト名>",
+
+		// Validate command
+		"validate.short":                    "設定ファイルを検証",
+		"validate.long":                     "設定ファイルの構文エラーをチェックし、すべての必須フィールドが存在することを確認します。",
+		"validate.noConfig":                 "設定ファイルが存在しません: %s\n'toske init' を実行して作成してください。",
+		"validate.checking":                 "設定ファイルを確認しています: %s",
+		"validate.readError":                "設定ファイルの読み込みに失敗しました: %v",
+		"validate.parseError":               "設定ファイルのパースに失敗しました: %v",
+		"validate.success":                  "✓ 設定ファイルは正常です！",
+		"validate.projectCount":             "  %d 個のプロジェクトが設定されています",
+		"validate.error.noVersion":          "設定エラー: 'version' フィールドは必須です",
+		"validate.error.noProjects":         "設定エラー: 少なくとも1つのプロジェクトを定義する必要があります",
+		"validate.error.projectNoName":      "設定エラー: プロジェクト #%d に 'name' フィールドがありません",
+		"validate.error.duplicateName":      "設定エラー: プロジェクト名 '%s' が重複しています",
+		"validate.error.projectNoRepo":      "設定エラー: プロジェクト '%s' に 'repo' フィールドがありません",
+		"validate.error.projectNoBranch":    "設定エラー: プロジェクト '%s' に 'branch' フィールドがありません",
+		"validate.error.invalidRetention":   "設定エラー: プロジェクト '%s' の backup_retention 値が無効です: %d (0以上である必要があります)",
 
 		// Config
 		"config.legacyWarning":       "⚠️  警告: レガシーの設定ファイル位置を使用しています。",


### PR DESCRIPTION
Add validate command to verify configuration file syntax and structure. The command checks for required fields, validates project configurations, and ensures data integrity.

Features:
- Validates YAML syntax and structure
- Checks for required fields (version, projects)
- Validates project configurations (name, repo, branch)
- Detects duplicate project names
- Validates backup_retention values
- Provides detailed error messages in both English and Japanese
- Includes comprehensive test coverage

Files added:
- cmd/validate.go: Core validation logic
- cmd/validate_test.go: Test suite with multiple test cases
- i18n/messages.go: i18n messages for validation feedback