### PR TITLE
Implement list command functionality

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/yk-lab/toske/i18n"
+)
+
+// ja: listCmd は list コマンドを表します
+// en: listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: i18n.T("list.short"),
+	Long:  i18n.T("list.long"),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runList(); err != nil {
+			fmt.Fprintf(os.Stderr, i18n.T("common.error")+"\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}
+
+func runList() error {
+	// ja: 設定ファイルパスを決定
+	// en: Determine config file path
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = getDefaultConfigPath()
+	}
+
+	// ja: 設定ファイルが存在するかチェック
+	// en: Check if config file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return fmt.Errorf(i18n.T("list.noConfig"), configPath)
+	}
+
+	// ja: 設定ファイルを読み込む
+	// en: Load configuration file
+	v := viper.New()
+	v.SetConfigFile(configPath)
+
+	if err := v.ReadInConfig(); err != nil {
+		return fmt.Errorf(i18n.T("list.readError"), err)
+	}
+
+	// ja: 設定を構造体にアンマーシャル
+	// en: Unmarshal config into struct
+	var config Config
+	if err := v.Unmarshal(&config); err != nil {
+		return fmt.Errorf(i18n.T("list.parseError"), err)
+	}
+
+	// ja: プロジェクトが存在しない場合
+	// en: If no projects exist
+	if len(config.Projects) == 0 {
+		fmt.Println(i18n.T("list.noProjects"))
+		return nil
+	}
+
+	// ja: プロジェクト一覧を表示
+	// en: Display project list
+	fmt.Println(i18n.T("list.header"))
+	fmt.Println()
+	for _, project := range config.Projects {
+		fmt.Printf("  • %s\n", project.Name)
+		fmt.Printf("    %s: %s\n", i18n.T("list.repo"), project.Repo)
+		fmt.Printf("    %s: %s\n", i18n.T("list.branch"), project.Branch)
+		if len(project.BackupPaths) > 0 {
+			fmt.Printf("    %s: %v\n", i18n.T("list.backupPaths"), project.BackupPaths)
+		}
+		if project.BackupRetention > 0 {
+			fmt.Printf("    %s: %d\n", i18n.T("list.retention"), project.BackupRetention)
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf(i18n.T("list.total")+"\n", len(config.Projects))
+
+	return nil
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -73,7 +73,10 @@ func runList() error {
 		fmt.Printf("    %s: %s\n", i18n.T("list.repo"), project.Repo)
 		fmt.Printf("    %s: %s\n", i18n.T("list.branch"), project.Branch)
 		if len(project.BackupPaths) > 0 {
-			fmt.Printf("    %s: %v\n", i18n.T("list.backupPaths"), project.BackupPaths)
+			fmt.Printf("    %s:\n", i18n.T("list.backupPaths"))
+			for _, path := range project.BackupPaths {
+				fmt.Printf("      - %s\n", path)
+			}
 		}
 		if project.BackupRetention > 0 {
 			fmt.Printf("    %s: %d\n", i18n.T("list.retention"), project.BackupRetention)

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -142,5 +145,184 @@ projects:
 	err := runList()
 	if err != nil {
 		t.Errorf("Expected no error but got: %v", err)
+	}
+}
+
+// TestRunListOutputValidation tests that the output contains expected project information
+func TestRunListOutputValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		configData     string
+		expectedOutput []string
+	}{
+		{
+			name: "single project output",
+			configData: `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+    branch: main
+    backup_paths:
+      - .env
+      - db.sqlite3
+    backup_retention: 5
+`,
+			expectedOutput: []string{
+				"test-project",
+				"git@github.com:user/test.git",
+				"main",
+				"- .env",
+				"- db.sqlite3",
+				"5",
+				"Total: 1",
+			},
+		},
+		{
+			name: "multiple projects output",
+			configData: `version: 1.0.0
+projects:
+  - name: project-alpha
+    repo: https://github.com/user/alpha.git
+    branch: develop
+    backup_retention: 3
+  - name: project-beta
+    repo: git@github.com:user/beta.git
+    branch: main
+`,
+			expectedOutput: []string{
+				"project-alpha",
+				"https://github.com/user/alpha.git",
+				"develop",
+				"project-beta",
+				"git@github.com:user/beta.git",
+				"main",
+				"Total: 2",
+			},
+		},
+		{
+			name: "empty projects output",
+			configData: `version: 1.0.0
+projects: []
+`,
+			expectedOutput: []string{
+				"No projects are registered yet",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary config file
+			tempDir := t.TempDir()
+			configPath := filepath.Join(tempDir, "config.yml")
+
+			if err := os.WriteFile(configPath, []byte(tt.configData), 0644); err != nil {
+				t.Fatalf("Failed to create test config file: %v", err)
+			}
+
+			// Set cfgFile to use our temporary config
+			originalCfgFile := cfgFile
+			cfgFile = configPath
+			defer func() {
+				cfgFile = originalCfgFile
+			}()
+
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			// Run list
+			err := runList()
+
+			// Restore stdout
+			w.Close()
+			os.Stdout = oldStdout
+
+			if err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+				return
+			}
+
+			// Read captured output
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			output := buf.String()
+
+			// Validate output contains expected strings
+			for _, expected := range tt.expectedOutput {
+				if !strings.Contains(output, expected) {
+					t.Errorf("Expected output to contain '%s', but it didn't.\nActual output:\n%s", expected, output)
+				}
+			}
+		})
+	}
+}
+
+// TestRunListBackupPathsFormat tests that backup paths are displayed as bullet list
+func TestRunListBackupPathsFormat(t *testing.T) {
+	configData := `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+    branch: main
+    backup_paths:
+      - .env
+      - config/database.yml
+      - storage/
+`
+
+	// Create temporary config file
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yml")
+
+	if err := os.WriteFile(configPath, []byte(configData), 0644); err != nil {
+		t.Fatalf("Failed to create test config file: %v", err)
+	}
+
+	// Set cfgFile to use our temporary config
+	originalCfgFile := cfgFile
+	cfgFile = configPath
+	defer func() {
+		cfgFile = originalCfgFile
+	}()
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Run list
+	err := runList()
+
+	// Restore stdout
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("Expected no error but got: %v", err)
+	}
+
+	// Read captured output
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	// Verify backup paths are shown as bullet list
+	expectedPaths := []string{
+		"      - .env",
+		"      - config/database.yml",
+		"      - storage/",
+	}
+
+	for _, expected := range expectedPaths {
+		if !strings.Contains(output, expected) {
+			t.Errorf("Expected output to contain backup path '%s' in bullet format, but it didn't.\nActual output:\n%s", expected, output)
+		}
+	}
+
+	// Verify it's NOT using Go slice format
+	if strings.Contains(output, "[.env config/database.yml storage/]") {
+		t.Error("Output should not contain Go slice format for backup paths")
 	}
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunList(t *testing.T) {
+	tests := []struct {
+		name        string
+		configData  string
+		expectError bool
+	}{
+		{
+			name: "valid config with single project",
+			configData: `version: 1.0.0
+projects:
+  - name: sample-project
+    repo: git@github.com:user/sample-project.git
+    branch: main
+    backup_paths:
+      - .env
+      - db.sqlite3
+    backup_retention: 3
+`,
+			expectError: false,
+		},
+		{
+			name: "valid config with multiple projects",
+			configData: `version: 1.0.0
+projects:
+  - name: project-one
+    repo: git@github.com:user/project-one.git
+    branch: main
+    backup_paths:
+      - .env
+    backup_retention: 3
+  - name: project-two
+    repo: https://github.com/user/project-two.git
+    branch: develop
+    backup_paths:
+      - .env
+      - db/
+    backup_retention: 5
+`,
+			expectError: false,
+		},
+		{
+			name: "empty projects list",
+			configData: `version: 1.0.0
+projects: []
+`,
+			expectError: false,
+		},
+		{
+			name: "invalid yaml",
+			configData: `version: 1.0.0
+projects:
+  - name: sample-project
+    repo: git@github.com:user/sample-project.git
+    branch: main
+  invalid yaml here
+`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary config file
+			tempDir := t.TempDir()
+			configPath := filepath.Join(tempDir, "config.yml")
+
+			if err := os.WriteFile(configPath, []byte(tt.configData), 0644); err != nil {
+				t.Fatalf("Failed to create test config file: %v", err)
+			}
+
+			// Set cfgFile to use our temporary config
+			originalCfgFile := cfgFile
+			cfgFile = configPath
+			defer func() {
+				cfgFile = originalCfgFile
+			}()
+
+			// Run list
+			err := runList()
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunListNoConfig(t *testing.T) {
+	// Create temporary directory without config file
+	tempDir := t.TempDir()
+	nonExistentPath := filepath.Join(tempDir, "nonexistent.yml")
+
+	// Set cfgFile to non-existent path
+	originalCfgFile := cfgFile
+	cfgFile = nonExistentPath
+	defer func() {
+		cfgFile = originalCfgFile
+	}()
+
+	// Run list - should fail because config doesn't exist
+	err := runList()
+	if err == nil {
+		t.Errorf("Expected error for non-existent config file but got nil")
+	}
+}
+
+func TestRunListWithMinimalProject(t *testing.T) {
+	// Test with minimal project configuration (no optional fields)
+	configData := `version: 1.0.0
+projects:
+  - name: minimal-project
+    repo: git@github.com:user/minimal.git
+    branch: main
+`
+
+	// Create temporary config file
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yml")
+
+	if err := os.WriteFile(configPath, []byte(configData), 0644); err != nil {
+		t.Fatalf("Failed to create test config file: %v", err)
+	}
+
+	// Set cfgFile to use our temporary config
+	originalCfgFile := cfgFile
+	cfgFile = configPath
+	defer func() {
+		cfgFile = originalCfgFile
+	}()
+
+	// Run list - should succeed
+	err := runList()
+	if err != nil {
+		t.Errorf("Expected no error but got: %v", err)
+	}
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -229,11 +229,14 @@ projects: []
 
 			// Capture stdout
 			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("Failed to create pipe: %v", err)
+			}
 			os.Stdout = w
 
 			// Run list
-			err := runList()
+			err = runList()
 
 			// Restore stdout
 			w.Close()
@@ -246,7 +249,9 @@ projects: []
 
 			// Read captured output
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			if _, err := io.Copy(&buf, r); err != nil {
+				t.Fatalf("Failed to read output: %v", err)
+			}
 			output := buf.String()
 
 			// Validate output contains expected strings
@@ -289,11 +294,14 @@ projects:
 
 	// Capture stdout
 	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
 	os.Stdout = w
 
 	// Run list
-	err := runList()
+	err = runList()
 
 	// Restore stdout
 	w.Close()
@@ -305,7 +313,9 @@ projects:
 
 	// Read captured output
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("Failed to read output: %v", err)
+	}
 	output := buf.String()
 
 	// Verify backup paths are shown as bullet list

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -1,0 +1,18 @@
+package cmd
+
+// ja: Config は設定ファイルの構造を表します
+// en: Config represents the structure of the configuration file
+type Config struct {
+	Version  string    `mapstructure:"version"`
+	Projects []Project `mapstructure:"projects"`
+}
+
+// ja: Project はプロジェクト設定を表します
+// en: Project represents a project configuration
+type Project struct {
+	Name            string   `mapstructure:"name"`
+	Repo            string   `mapstructure:"repo"`
+	Branch          string   `mapstructure:"branch"`
+	BackupPaths     []string `mapstructure:"backup_paths"`
+	BackupRetention int      `mapstructure:"backup_retention"`
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -9,23 +9,6 @@ import (
 	"github.com/yk-lab/toske/i18n"
 )
 
-// ja: Config は設定ファイルの構造を表します
-// en: Config represents the structure of the configuration file
-type Config struct {
-	Version  string    `mapstructure:"version"`
-	Projects []Project `mapstructure:"projects"`
-}
-
-// ja: Project はプロジェクト設定を表します
-// en: Project represents a project configuration
-type Project struct {
-	Name            string   `mapstructure:"name"`
-	Repo            string   `mapstructure:"repo"`
-	Branch          string   `mapstructure:"branch"`
-	BackupPaths     []string `mapstructure:"backup_paths"`
-	BackupRetention int      `mapstructure:"backup_retention"`
-}
-
 // ja: validateCmd は validate コマンドを表します
 // en: validateCmd represents the validate command
 var validateCmd = &cobra.Command{

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -71,6 +71,20 @@ You can override the default path by setting the TOSKE_CONFIG environment variab
 		"validate.error.projectNoBranch":    "Configuration error: project '%s' is missing the 'branch' field",
 		"validate.error.invalidRetention":   "Configuration error: project '%s' has invalid backup_retention value: %d (must be >= 0)",
 
+		// List command
+		"list.short":       "List all registered projects",
+		"list.long":        "Display a list of all projects registered in the configuration file.",
+		"list.noConfig":    "Configuration file does not exist: %s\nRun 'toske init' to create one.",
+		"list.readError":   "Failed to read configuration file: %v",
+		"list.parseError":  "Failed to parse configuration file: %v",
+		"list.noProjects":  "No projects are registered yet.\nRun 'toske edit' to add projects to your configuration.",
+		"list.header":      "Registered Projects:",
+		"list.repo":        "Repository",
+		"list.branch":      "Branch",
+		"list.backupPaths": "Backup Paths",
+		"list.retention":   "Retention",
+		"list.total":       "\nTotal: %d project(s)",
+
 		// Config
 		"config.legacyWarning":       "⚠️  WARNING: You are using a legacy configuration file location.",
 		"config.legacyWarningDetail": "   Please migrate to ~/.config/toske/config.yml by running: mv ~/.toske.yaml ~/.config/toske/config.yml",
@@ -145,6 +159,20 @@ TOSKE_CONFIG 環境変数を設定することで、デフォルトパスを上�
 		"validate.error.projectNoRepo":      "設定エラー: プロジェクト '%s' に 'repo' フィールドがありません",
 		"validate.error.projectNoBranch":    "設定エラー: プロジェクト '%s' に 'branch' フィールドがありません",
 		"validate.error.invalidRetention":   "設定エラー: プロジェクト '%s' の backup_retention 値が無効です: %d (0以上である必要があります)",
+
+		// List command
+		"list.short":       "登録済みプロジェクトの一覧を表示",
+		"list.long":        "設定ファイルに登録されているすべてのプロジェクトの一覧を表示します。",
+		"list.noConfig":    "設定ファイルが存在しません: %s\n'toske init' を実行して作成してください。",
+		"list.readError":   "設定ファイルの読み込みに失敗しました: %v",
+		"list.parseError":  "設定ファイルのパースに失敗しました: %v",
+		"list.noProjects":  "プロジェクトが登録されていません。\n'toske edit' を実行して設定ファイルにプロジェクトを追加してください。",
+		"list.header":      "登録済みプロジェクト:",
+		"list.repo":        "リポジトリ",
+		"list.branch":      "ブランチ",
+		"list.backupPaths": "バックアップパス",
+		"list.retention":   "保持件数",
+		"list.total":       "\n合計: %d 件",
 
 		// Config
 		"config.legacyWarning":       "⚠️  警告: レガシーの設定ファイル位置を使用しています。",


### PR DESCRIPTION
This commit adds the list command that displays all registered projects from the configuration file. The implementation includes:

- New list command that reads the config file and displays projects
- Display of project details (name, repo, branch, backup paths, retention)
- Internationalization support for both English and Japanese
- Comprehensive test coverage for various scenarios
- Proper error handling for missing or invalid config files

The list command follows the same patterns as existing commands (validate, edit, etc.) and integrates seamlessly with the CLI.