### PR TITLE
Implement delete command functionality

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/yk-lab/toske/i18n"
+	"gopkg.in/yaml.v3"
+)
+
+var deleteProjectName string
+
+// ja: deleteCmd は delete コマンドを表します
+// en: deleteCmd represents the delete command
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: i18n.T("delete.short"),
+	Long:  i18n.T("delete.long"),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runDelete(); err != nil {
+			fmt.Fprintf(os.Stderr, i18n.T("common.error")+"\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deleteCmd)
+	deleteCmd.Flags().StringVarP(&deleteProjectName, "project", "p", "", i18n.T("delete.flag.project"))
+}
+
+func runDelete() error {
+	// ja: プロジェクト名が指定されているかチェック
+	// en: Check if project name is specified
+	if deleteProjectName == "" {
+		return fmt.Errorf("%s", i18n.T("delete.noProjectFlag"))
+	}
+
+	// ja: 設定ファイルパスを決定
+	// en: Determine config file path
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = getDefaultConfigPath()
+	}
+
+	// ja: 設定ファイルが存在するかチェック
+	// en: Check if config file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return fmt.Errorf(i18n.T("delete.noConfig"), configPath)
+	}
+
+	// ja: 設定ファイルを読み込む
+	// en: Load configuration file
+	v := viper.New()
+	v.SetConfigFile(configPath)
+
+	if err := v.ReadInConfig(); err != nil {
+		return fmt.Errorf(i18n.T("delete.readError"), err)
+	}
+
+	// ja: 設定を構造体にアンマーシャル
+	// en: Unmarshal config into struct
+	var config Config
+	if err := v.Unmarshal(&config); err != nil {
+		return fmt.Errorf(i18n.T("delete.parseError"), err)
+	}
+
+	// ja: 指定されたプロジェクトを検索
+	// en: Find the specified project
+	projectIndex := -1
+	for i := range config.Projects {
+		if config.Projects[i].Name == deleteProjectName {
+			projectIndex = i
+			break
+		}
+	}
+
+	if projectIndex == -1 {
+		return fmt.Errorf(i18n.T("delete.projectNotFound"), deleteProjectName)
+	}
+
+	// ja: 削除確認プロンプトを表示
+	// en: Show confirmation prompt
+	fmt.Printf(i18n.T("delete.confirmPrompt"), deleteProjectName)
+
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf(i18n.T("delete.readInputError"), err)
+	}
+
+	// ja: 入力をトリムして小文字に変換
+	// en: Trim and convert input to lowercase
+	response = strings.ToLower(strings.TrimSpace(response))
+
+	// ja: yまたはyes以外の場合はキャンセル
+	// en: Cancel if response is not y or yes
+	if response != "y" && response != "yes" {
+		fmt.Println(i18n.T("delete.cancelled"))
+		return nil
+	}
+
+	// ja: プロジェクトを削除
+	// en: Delete the project
+	config.Projects = append(config.Projects[:projectIndex], config.Projects[projectIndex+1:]...)
+
+	// ja: 設定ファイルを更新
+	// en: Update configuration file
+	data, err := yaml.Marshal(&config)
+	if err != nil {
+		return fmt.Errorf(i18n.T("delete.writeError"), err)
+	}
+
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		return fmt.Errorf(i18n.T("delete.writeError"), err)
+	}
+
+	fmt.Printf(i18n.T("delete.success")+"\n", deleteProjectName)
+
+	return nil
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -40,6 +40,10 @@ func runDelete() error {
 		return fmt.Errorf("%s", i18n.T("delete.noProjectFlag"))
 	}
 
+	// ja: プロジェクト名の前後の空白を削除
+	// en: Trim leading and trailing whitespace from project name
+	deleteProjectName = strings.TrimSpace(deleteProjectName)
+
 	// ja: 設定ファイルパスを決定
 	// en: Determine config file path
 	configPath := cfgFile

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -12,7 +12,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var deleteProjectName string
+var (
+	deleteProjectName string
+	deleteForce       bool
+)
 
 // ja: deleteCmd は delete コマンドを表します
 // en: deleteCmd represents the delete command
@@ -31,18 +34,20 @@ var deleteCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(deleteCmd)
 	deleteCmd.Flags().StringVarP(&deleteProjectName, "project", "p", "", i18n.T("delete.flag.project"))
+	deleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, i18n.T("delete.flag.force"))
+	deleteCmd.MarkFlagRequired("project")
 }
 
 func runDelete() error {
-	// ja: プロジェクト名が指定されているかチェック
-	// en: Check if project name is specified
-	if deleteProjectName == "" {
-		return fmt.Errorf("%s", i18n.T("delete.noProjectFlag"))
-	}
-
 	// ja: プロジェクト名の前後の空白を削除
 	// en: Trim leading and trailing whitespace from project name
 	deleteProjectName = strings.TrimSpace(deleteProjectName)
+
+	// ja: プロジェクト名が空でないかチェック (Cobra の MarkFlagRequired のバックアップ)
+	// en: Check project name is not empty (backup for Cobra's MarkFlagRequired)
+	if deleteProjectName == "" {
+		return fmt.Errorf("%s", i18n.T("delete.noProjectFlag"))
+	}
 
 	// ja: 設定ファイルパスを決定
 	// en: Determine config file path
@@ -59,51 +64,25 @@ func runDelete() error {
 
 	// ja: 設定ファイルを読み込む
 	// en: Load configuration file
-	v := viper.New()
-	v.SetConfigFile(configPath)
-
-	if err := v.ReadInConfig(); err != nil {
-		return fmt.Errorf(i18n.T("delete.readError"), err)
-	}
-
-	// ja: 設定を構造体にアンマーシャル
-	// en: Unmarshal config into struct
-	var config Config
-	if err := v.Unmarshal(&config); err != nil {
-		return fmt.Errorf(i18n.T("delete.parseError"), err)
+	config, err := loadDeleteConfig(configPath)
+	if err != nil {
+		return err
 	}
 
 	// ja: 指定されたプロジェクトを検索
 	// en: Find the specified project
-	projectIndex := -1
-	for i := range config.Projects {
-		if config.Projects[i].Name == deleteProjectName {
-			projectIndex = i
-			break
-		}
-	}
-
+	projectIndex := findProjectIndex(config.Projects, deleteProjectName)
 	if projectIndex == -1 {
 		return fmt.Errorf(i18n.T("delete.projectNotFound"), deleteProjectName)
 	}
 
-	// ja: 削除確認プロンプトを表示
-	// en: Show confirmation prompt
-	fmt.Printf(i18n.T("delete.confirmPrompt"), deleteProjectName)
-
-	reader := bufio.NewReader(os.Stdin)
-	response, err := reader.ReadString('\n')
+	// ja: 削除確認
+	// en: Confirm deletion
+	confirmed, err := confirmDeletion(deleteProjectName, deleteForce)
 	if err != nil {
-		return fmt.Errorf(i18n.T("delete.readInputError"), err)
+		return err
 	}
-
-	// ja: 入力をトリムして小文字に変換
-	// en: Trim and convert input to lowercase
-	response = strings.ToLower(strings.TrimSpace(response))
-
-	// ja: yまたはyes以外の場合はキャンセル
-	// en: Cancel if response is not y or yes
-	if response != "y" && response != "yes" {
+	if !confirmed {
 		fmt.Println(i18n.T("delete.cancelled"))
 		return nil
 	}
@@ -112,18 +91,85 @@ func runDelete() error {
 	// en: Delete the project
 	config.Projects = append(config.Projects[:projectIndex], config.Projects[projectIndex+1:]...)
 
-	// ja: 設定ファイルを更新
-	// en: Update configuration file
-	data, err := yaml.Marshal(&config)
-	if err != nil {
-		return fmt.Errorf(i18n.T("delete.writeError"), err)
-	}
-
-	if err := os.WriteFile(configPath, data, 0644); err != nil {
-		return fmt.Errorf(i18n.T("delete.writeError"), err)
+	// ja: 設定ファイルを保存
+	// en: Save configuration file
+	if err := saveConfig(configPath, &config); err != nil {
+		return err
 	}
 
 	fmt.Printf(i18n.T("delete.success")+"\n", deleteProjectName)
+
+	return nil
+}
+
+// ja: loadDeleteConfig は設定ファイルを読み込みます
+// en: loadDeleteConfig loads the configuration file
+func loadDeleteConfig(configPath string) (Config, error) {
+	v := viper.New()
+	v.SetConfigFile(configPath)
+
+	if err := v.ReadInConfig(); err != nil {
+		return Config{}, fmt.Errorf(i18n.T("delete.readError"), err)
+	}
+
+	var config Config
+	if err := v.Unmarshal(&config); err != nil {
+		return Config{}, fmt.Errorf(i18n.T("delete.parseError"), err)
+	}
+
+	return config, nil
+}
+
+// ja: findProjectIndex はプロジェクト名からインデックスを検索します
+// en: findProjectIndex finds the index of a project by name
+func findProjectIndex(projects []Project, name string) int {
+	for i := range projects {
+		if projects[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// ja: confirmDeletion は削除の確認を行います
+// en: confirmDeletion confirms the deletion
+func confirmDeletion(projectName string, force bool) (bool, error) {
+	// ja: --force フラグが指定されている場合は確認をスキップ
+	// en: Skip confirmation if --force flag is specified
+	if force {
+		return true, nil
+	}
+
+	// ja: 削除確認プロンプトを表示
+	// en: Show confirmation prompt
+	fmt.Printf(i18n.T("delete.confirmPrompt"), projectName)
+
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf(i18n.T("delete.readInputError"), err)
+	}
+
+	// ja: 入力をトリムして小文字に変換
+	// en: Trim and convert input to lowercase
+	response = strings.ToLower(strings.TrimSpace(response))
+
+	// ja: yまたはyes以外の場合はキャンセル
+	// en: Cancel if response is not y or yes
+	return response == "y" || response == "yes", nil
+}
+
+// ja: saveConfig は設定ファイルを保存します
+// en: saveConfig saves the configuration file
+func saveConfig(configPath string, config *Config) error {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf(i18n.T("delete.marshalError"), err)
+	}
+
+	if err := os.WriteFile(configPath, data, 0600); err != nil {
+		return fmt.Errorf(i18n.T("delete.writeError"), err)
+	}
 
 	return nil
 }

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -513,6 +513,224 @@ projects:
 	}
 }
 
+// TestDeleteWithForceFlag tests that --force flag skips confirmation prompt
+func TestDeleteWithForceFlag(t *testing.T) {
+	configData := `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+    branch: main
+  - name: other-project
+    repo: git@github.com:user/other.git
+    branch: main
+`
+
+	defer setupTestConfig(t, configData)()
+
+	// Set flags - no stdin setup needed because --force skips prompt
+	originalProjectName := deleteProjectName
+	originalForce := deleteForce
+	deleteProjectName = "test-project"
+	deleteForce = true
+	defer func() {
+		deleteProjectName = originalProjectName
+		deleteForce = originalForce
+	}()
+
+	// Run delete - should succeed without stdin
+	err := runDelete()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify project was deleted
+	v := viper.New()
+	v.SetConfigFile(cfgFile)
+	if err := v.ReadInConfig(); err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+
+	var config Config
+	if err := v.Unmarshal(&config); err != nil {
+		t.Fatalf("Failed to unmarshal config: %v", err)
+	}
+
+	if len(config.Projects) != 1 {
+		t.Errorf("Expected 1 remaining project, got %d", len(config.Projects))
+	}
+	if len(config.Projects) > 0 && config.Projects[0].Name != "other-project" {
+		t.Errorf("Expected 'other-project' to remain, got '%s'", config.Projects[0].Name)
+	}
+}
+
+// TestFindProjectIndex tests the findProjectIndex helper function
+func TestFindProjectIndex(t *testing.T) {
+	projects := []Project{
+		{Name: "first"},
+		{Name: "second"},
+		{Name: "third"},
+	}
+
+	tests := []struct {
+		name     string
+		projects []Project
+		search   string
+		expected int
+	}{
+		{
+			name:     "find first project",
+			projects: projects,
+			search:   "first",
+			expected: 0,
+		},
+		{
+			name:     "find middle project",
+			projects: projects,
+			search:   "second",
+			expected: 1,
+		},
+		{
+			name:     "find last project",
+			projects: projects,
+			search:   "third",
+			expected: 2,
+		},
+		{
+			name:     "project not found",
+			projects: projects,
+			search:   "nonexistent",
+			expected: -1,
+		},
+		{
+			name:     "empty projects list",
+			projects: []Project{},
+			search:   "any",
+			expected: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findProjectIndex(tt.projects, tt.search)
+			if result != tt.expected {
+				t.Errorf("Expected index %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestConfirmDeletion tests the confirmDeletion function
+func TestConfirmDeletion(t *testing.T) {
+	tests := []struct {
+		name     string
+		force    bool
+		input    string
+		expected bool
+	}{
+		{
+			name:     "force flag true",
+			force:    true,
+			input:    "", // no input needed
+			expected: true,
+		},
+		{
+			name:     "confirm with y",
+			force:    false,
+			input:    "y\n",
+			expected: true,
+		},
+		{
+			name:     "confirm with yes",
+			force:    false,
+			input:    "yes\n",
+			expected: true,
+		},
+		{
+			name:     "cancel with n",
+			force:    false,
+			input:    "n\n",
+			expected: false,
+		},
+		{
+			name:     "cancel with empty",
+			force:    false,
+			input:    "\n",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.force {
+				// Setup stdin mock
+				tmpfile, err := os.CreateTemp("", "stdin")
+				if err != nil {
+					t.Fatalf("Failed to create temp file: %v", err)
+				}
+				defer os.Remove(tmpfile.Name())
+
+				if _, err := tmpfile.WriteString(tt.input); err != nil {
+					t.Fatalf("Failed to write to temp file: %v", err)
+				}
+
+				if _, err := tmpfile.Seek(0, 0); err != nil {
+					t.Fatalf("Failed to seek temp file: %v", err)
+				}
+
+				oldStdin := os.Stdin
+				os.Stdin = tmpfile
+				defer func() {
+					os.Stdin = oldStdin
+					tmpfile.Close()
+				}()
+			}
+
+			result, err := confirmDeletion("test-project", tt.force)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestSaveConfigPermissions tests that config file is saved with 0600 permissions
+func TestSaveConfigPermissions(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yml")
+
+	config := Config{
+		Version: "1.0.0",
+		Projects: []Project{
+			{
+				Name:   "test",
+				Repo:   "git@github.com:user/test.git",
+				Branch: "main",
+			},
+		},
+	}
+
+	err := saveConfig(configPath, &config)
+	if err != nil {
+		t.Fatalf("Failed to save config: %v", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("Failed to stat config file: %v", err)
+	}
+
+	// Check file permissions
+	mode := info.Mode().Perm()
+	expected := os.FileMode(0600)
+	if mode != expected {
+		t.Errorf("Expected file permissions %o, got %o", expected, mode)
+	}
+}
+
 // TestDeleteMultipleProjectsOrder tests that deleting a project maintains the order of remaining projects
 func TestDeleteMultipleProjectsOrder(t *testing.T) {
 	configData := `version: 1.0.0

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -1,0 +1,424 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestRunDelete(t *testing.T) {
+	tests := []struct {
+		name            string
+		projectName     string
+		configData      string
+		userInput       string
+		expectError     bool
+		errorMessage    string
+		expectedRemains []string
+	}{
+		{
+			name:        "successful deletion with yes confirmation",
+			projectName: "test-project",
+			configData: `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+    branch: main
+    backup_paths:
+      - .env
+    backup_retention: 3
+  - name: other-project
+    repo: git@github.com:user/other.git
+    branch: main
+`,
+			userInput:       "y\n",
+			expectError:     false,
+			expectedRemains: []string{"other-project"},
+		},
+		{
+			name:        "successful deletion with yes (full word) confirmation",
+			projectName: "test-project",
+			configData: `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+    branch: main
+  - name: another-project
+    repo: git@github.com:user/another.git
+    branch: develop
+`,
+			userInput:       "yes\n",
+			expectError:     false,
+			expectedRemains: []string{"another-project"},
+		},
+		{
+			name:        "cancelled deletion with no",
+			projectName: "test-project",
+			configData: `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+    branch: main
+`,
+			userInput:       "n\n",
+			expectError:     false,
+			expectedRemains: []string{"test-project"},
+		},
+		{
+			name:        "cancelled deletion with enter (default no)",
+			projectName: "test-project",
+			configData: `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+    branch: main
+`,
+			userInput:       "\n",
+			expectError:     false,
+			expectedRemains: []string{"test-project"},
+		},
+		{
+			name:        "project not found",
+			projectName: "nonexistent",
+			configData: `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+    branch: main
+`,
+			userInput:    "",
+			expectError:  true,
+			errorMessage: "not found in configuration file",
+		},
+		{
+			name:         "missing project flag",
+			projectName:  "",
+			configData:   `version: 1.0.0\nprojects: []`,
+			userInput:    "",
+			expectError:  true,
+			errorMessage: "Project name is required",
+		},
+		{
+			name:        "delete last remaining project",
+			projectName: "test-project",
+			configData: `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+    branch: main
+`,
+			userInput:       "y\n",
+			expectError:     false,
+			expectedRemains: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup config
+			defer setupTestConfig(t, tt.configData)()
+
+			// Setup stdin mock
+			if tt.userInput != "" {
+				// Create a temporary file for stdin
+				tmpfile, err := os.CreateTemp("", "stdin")
+				if err != nil {
+					t.Fatalf("Failed to create temp file: %v", err)
+				}
+				defer os.Remove(tmpfile.Name())
+
+				if _, err := tmpfile.WriteString(tt.userInput); err != nil {
+					t.Fatalf("Failed to write to temp file: %v", err)
+				}
+
+				if _, err := tmpfile.Seek(0, 0); err != nil {
+					t.Fatalf("Failed to seek temp file: %v", err)
+				}
+
+				oldStdin := os.Stdin
+				os.Stdin = tmpfile
+				defer func() {
+					os.Stdin = oldStdin
+					tmpfile.Close()
+				}()
+			}
+
+			// Set project name
+			originalProjectName := deleteProjectName
+			deleteProjectName = tt.projectName
+			defer func() { deleteProjectName = originalProjectName }()
+
+			// Run delete
+			err := runDelete()
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if tt.errorMessage != "" && !strings.Contains(err.Error(), tt.errorMessage) {
+					t.Errorf("Expected error message to contain '%s', got: %v", tt.errorMessage, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+
+				// Verify remaining projects
+				v := viper.New()
+				v.SetConfigFile(cfgFile)
+				if err := v.ReadInConfig(); err != nil {
+					t.Fatalf("Failed to read config after deletion: %v", err)
+				}
+
+				var config Config
+				if err := v.Unmarshal(&config); err != nil {
+					t.Fatalf("Failed to unmarshal config: %v", err)
+				}
+
+				if len(config.Projects) != len(tt.expectedRemains) {
+					t.Errorf("Expected %d remaining projects, got %d", len(tt.expectedRemains), len(config.Projects))
+				}
+
+				for i, expectedName := range tt.expectedRemains {
+					if i >= len(config.Projects) {
+						t.Errorf("Expected project '%s' to remain, but it doesn't exist", expectedName)
+						continue
+					}
+					if config.Projects[i].Name != expectedName {
+						t.Errorf("Expected project '%s' at position %d, got '%s'", expectedName, i, config.Projects[i].Name)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRunDeleteNoConfig(t *testing.T) {
+	// Create temporary directory without config file
+	tempDir := t.TempDir()
+	nonExistentPath := filepath.Join(tempDir, "nonexistent.yml")
+
+	// Set cfgFile to non-existent path
+	originalCfgFile := cfgFile
+	cfgFile = nonExistentPath
+	defer func() {
+		cfgFile = originalCfgFile
+	}()
+
+	// Set project name
+	originalProjectName := deleteProjectName
+	deleteProjectName = "test-project"
+	defer func() { deleteProjectName = originalProjectName }()
+
+	// Run delete - should fail because config doesn't exist
+	err := runDelete()
+	if err == nil {
+		t.Errorf("Expected error for non-existent config file but got nil")
+	}
+}
+
+func TestRunDeleteInvalidYAML(t *testing.T) {
+	// Create temporary config with invalid YAML
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yml")
+
+	invalidYAML := `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+  invalid yaml here
+`
+
+	if err := os.WriteFile(configPath, []byte(invalidYAML), 0644); err != nil {
+		t.Fatalf("Failed to create test config file: %v", err)
+	}
+
+	originalCfgFile := cfgFile
+	cfgFile = configPath
+	defer func() { cfgFile = originalCfgFile }()
+
+	// Set project name
+	originalProjectName := deleteProjectName
+	deleteProjectName = "test-project"
+	defer func() { deleteProjectName = originalProjectName }()
+
+	// Run delete - should fail on parsing
+	err := runDelete()
+	if err == nil {
+		t.Errorf("Expected error for invalid YAML but got nil")
+	}
+}
+
+func TestDeleteConfirmationInput(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		shouldDelete  bool
+	}{
+		{"lowercase y", "y", true},
+		{"uppercase Y", "Y", true},
+		{"lowercase yes", "yes", true},
+		{"uppercase YES", "YES", true},
+		{"mixed case Yes", "Yes", true},
+		{"lowercase n", "n", false},
+		{"uppercase N", "N", false},
+		{"lowercase no", "no", false},
+		{"uppercase NO", "NO", false},
+		{"empty input", "", false},
+		{"whitespace", "  ", false},
+		{"random text", "maybe", false},
+		{"y with whitespace", " y ", true},
+		{"yes with whitespace", " yes ", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test config
+			configData := `version: 1.0.0
+projects:
+  - name: test-project
+    repo: git@github.com:user/test.git
+    branch: main
+`
+			defer setupTestConfig(t, configData)()
+
+			// Setup stdin mock
+			tmpfile, err := os.CreateTemp("", "stdin")
+			if err != nil {
+				t.Fatalf("Failed to create temp file: %v", err)
+			}
+			defer os.Remove(tmpfile.Name())
+
+			if _, err := tmpfile.WriteString(tt.input + "\n"); err != nil {
+				t.Fatalf("Failed to write to temp file: %v", err)
+			}
+
+			if _, err := tmpfile.Seek(0, 0); err != nil {
+				t.Fatalf("Failed to seek temp file: %v", err)
+			}
+
+			oldStdin := os.Stdin
+			os.Stdin = tmpfile
+			defer func() {
+				os.Stdin = oldStdin
+				tmpfile.Close()
+			}()
+
+			// Set project name
+			originalProjectName := deleteProjectName
+			deleteProjectName = "test-project"
+			defer func() { deleteProjectName = originalProjectName }()
+
+			// Run delete
+			err = runDelete()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// Verify project was deleted or not
+			v := viper.New()
+			v.SetConfigFile(cfgFile)
+			if err := v.ReadInConfig(); err != nil {
+				t.Fatalf("Failed to read config: %v", err)
+			}
+
+			var config Config
+			if err := v.Unmarshal(&config); err != nil {
+				t.Fatalf("Failed to unmarshal config: %v", err)
+			}
+
+			projectExists := false
+			for _, project := range config.Projects {
+				if project.Name == "test-project" {
+					projectExists = true
+					break
+				}
+			}
+
+			if tt.shouldDelete && projectExists {
+				t.Errorf("Expected project to be deleted, but it still exists")
+			}
+			if !tt.shouldDelete && !projectExists {
+				t.Errorf("Expected project to remain, but it was deleted")
+			}
+		})
+	}
+}
+
+// TestDeleteMultipleProjectsOrder tests that deleting a project maintains the order of remaining projects
+func TestDeleteMultipleProjectsOrder(t *testing.T) {
+	configData := `version: 1.0.0
+projects:
+  - name: first-project
+    repo: git@github.com:user/first.git
+    branch: main
+  - name: second-project
+    repo: git@github.com:user/second.git
+    branch: main
+  - name: third-project
+    repo: git@github.com:user/third.git
+    branch: main
+  - name: fourth-project
+    repo: git@github.com:user/fourth.git
+    branch: main
+`
+
+	defer setupTestConfig(t, configData)()
+
+	// Setup stdin to confirm deletion
+	tmpfile, err := os.CreateTemp("", "stdin")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.WriteString("y\n"); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+
+	if _, err := tmpfile.Seek(0, 0); err != nil {
+		t.Fatalf("Failed to seek temp file: %v", err)
+	}
+
+	oldStdin := os.Stdin
+	os.Stdin = tmpfile
+	defer func() {
+		os.Stdin = oldStdin
+		tmpfile.Close()
+	}()
+
+	// Delete second-project
+	originalProjectName := deleteProjectName
+	deleteProjectName = "second-project"
+	defer func() { deleteProjectName = originalProjectName }()
+
+	err = runDelete()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify remaining projects are in correct order
+	v := viper.New()
+	v.SetConfigFile(cfgFile)
+	if err := v.ReadInConfig(); err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+
+	var config Config
+	if err := v.Unmarshal(&config); err != nil {
+		t.Fatalf("Failed to unmarshal config: %v", err)
+	}
+
+	expectedProjects := []string{"first-project", "third-project", "fourth-project"}
+	if len(config.Projects) != len(expectedProjects) {
+		t.Fatalf("Expected %d projects, got %d", len(expectedProjects), len(config.Projects))
+	}
+
+	for i, expected := range expectedProjects {
+		if config.Projects[i].Name != expected {
+			t.Errorf("Expected project '%s' at position %d, got '%s'", expected, i, config.Projects[i].Name)
+		}
+	}
+}

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -3,16 +3,16 @@ package cmd
 // ja: Config は設定ファイルの構造を表します
 // en: Config represents the structure of the configuration file
 type Config struct {
-	Version  string    `mapstructure:"version"`
-	Projects []Project `mapstructure:"projects"`
+	Version  string    `mapstructure:"version" yaml:"version"`
+	Projects []Project `mapstructure:"projects" yaml:"projects"`
 }
 
 // ja: Project はプロジェクト設定を表します
 // en: Project represents a project configuration
 type Project struct {
-	Name            string   `mapstructure:"name"`
-	Repo            string   `mapstructure:"repo"`
-	Branch          string   `mapstructure:"branch"`
-	BackupPaths     []string `mapstructure:"backup_paths"`
-	BackupRetention int      `mapstructure:"backup_retention"`
+	Name            string   `mapstructure:"name" yaml:"name"`
+	Repo            string   `mapstructure:"repo" yaml:"repo"`
+	Branch          string   `mapstructure:"branch" yaml:"branch"`
+	BackupPaths     []string `mapstructure:"backup_paths" yaml:"backup_paths,omitempty"`
+	BackupRetention int      `mapstructure:"backup_retention" yaml:"backup_retention,omitempty"`
 }

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -120,9 +120,11 @@ You can override the default path by setting the TOSKE_CONFIG environment variab
 		"delete.confirmPrompt": "Are you sure you want to delete project '%s'? [y/N]: ",
 		"delete.cancelled":     "Deletion cancelled.",
 		"delete.readInputError": "Failed to read input: %v",
+		"delete.marshalError":  "Failed to marshal configuration: %v",
 		"delete.writeError":    "Failed to write configuration file: %v",
 		"delete.success":       "✓ Project '%s' has been successfully deleted from configuration.",
 		"delete.flag.project":  "Specify the project name to delete",
+		"delete.flag.force":    "Skip confirmation prompt (use with caution)",
 
 		// Config
 		"config.legacyWarning":       "⚠️  WARNING: You are using a legacy configuration file location.",
@@ -248,9 +250,11 @@ TOSKE_CONFIG 環境変数を設定することで、デフォルトパスを上�
 		"delete.confirmPrompt": "プロジェクト '%s' を本当に削除しますか？ [y/N]: ",
 		"delete.cancelled":     "削除をキャンセルしました。",
 		"delete.readInputError": "入力の読み取りに失敗しました: %v",
+		"delete.marshalError":  "設定のマーシャルに失敗しました: %v",
 		"delete.writeError":    "設定ファイルの書き込みに失敗しました: %v",
 		"delete.success":       "✓ プロジェクト '%s' を設定から正常に削除しました。",
 		"delete.flag.project":  "削除するプロジェクト名を指定",
+		"delete.flag.force":    "確認プロンプトをスキップ（注意して使用してください）",
 
 		// Config
 		"config.legacyWarning":       "⚠️  警告: レガシーの設定ファイル位置を使用しています。",

--- a/i18n/messages.go
+++ b/i18n/messages.go
@@ -109,6 +109,21 @@ You can override the default path by setting the TOSKE_CONFIG environment variab
 		"backup.backupLocation":           "  Backup location: %s",
 		"backup.flag.project":             "Specify the project name to backup",
 
+		// Delete command
+		"delete.short":         "Delete a project from configuration",
+		"delete.long":          "Remove a project from the configuration file. This does not delete any backup files.",
+		"delete.noConfig":      "Configuration file does not exist: %s\nRun 'toske init' to create one.",
+		"delete.readError":     "Failed to read configuration file: %v",
+		"delete.parseError":    "Failed to parse configuration file: %v",
+		"delete.noProjectFlag": "Project name is required. Use --project flag to specify the project.",
+		"delete.projectNotFound": "Project '%s' not found in configuration file.",
+		"delete.confirmPrompt": "Are you sure you want to delete project '%s'? [y/N]: ",
+		"delete.cancelled":     "Deletion cancelled.",
+		"delete.readInputError": "Failed to read input: %v",
+		"delete.writeError":    "Failed to write configuration file: %v",
+		"delete.success":       "✓ Project '%s' has been successfully deleted from configuration.",
+		"delete.flag.project":  "Specify the project name to delete",
+
 		// Config
 		"config.legacyWarning":       "⚠️  WARNING: You are using a legacy configuration file location.",
 		"config.legacyWarningDetail": "   Please migrate to ~/.config/toske/config.yml by running: mv ~/.toske.yaml ~/.config/toske/config.yml",
@@ -221,6 +236,21 @@ TOSKE_CONFIG 環境変数を設定することで、デフォルトパスを上�
 		"backup.success":                  "✓ バックアップが正常に完了しました！",
 		"backup.backupLocation":           "  バックアップの場所: %s",
 		"backup.flag.project":             "バックアップするプロジェクト名を指定",
+
+		// Delete command
+		"delete.short":         "設定からプロジェクトを削除",
+		"delete.long":          "設定ファイルからプロジェクトを削除します。バックアップファイルは削除されません。",
+		"delete.noConfig":      "設定ファイルが存在しません: %s\n'toske init' を実行して作成してください。",
+		"delete.readError":     "設定ファイルの読み込みに失敗しました: %v",
+		"delete.parseError":    "設定ファイルのパースに失敗しました: %v",
+		"delete.noProjectFlag": "プロジェクト名が必要です。--project フラグを使用してプロジェクトを指定してください。",
+		"delete.projectNotFound": "プロジェクト '%s' が設定ファイルに見つかりません。",
+		"delete.confirmPrompt": "プロジェクト '%s' を本当に削除しますか？ [y/N]: ",
+		"delete.cancelled":     "削除をキャンセルしました。",
+		"delete.readInputError": "入力の読み取りに失敗しました: %v",
+		"delete.writeError":    "設定ファイルの書き込みに失敗しました: %v",
+		"delete.success":       "✓ プロジェクト '%s' を設定から正常に削除しました。",
+		"delete.flag.project":  "削除するプロジェクト名を指定",
 
 		// Config
 		"config.legacyWarning":       "⚠️  警告: レガシーの設定ファイル位置を使用しています。",


### PR DESCRIPTION
Add delete command to remove projects from configuration:
- Add delete command with --project/-p flag
- Implement confirmation prompt for safe deletion
- Add comprehensive test suite covering various scenarios
- Add i18n messages for both English and Japanese
- Maintain project order after deletion
- Does not delete backup files, only removes from config